### PR TITLE
Cleanup: Consistent coding style

### DIFF
--- a/.circleci/check-format.sh
+++ b/.circleci/check-format.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
 echo "Checking code format"
-if [ -n $(git diff --name-only | grep -E "^(src|test).*(.cpp$|.h)$") ] ; then
+CHANGED_FILES="$(git diff --name-only | grep -E '^(src|test).*(.cpp$|.h)$')"
+if [ -n "${CHANGED_FILES}" ] ; then
     echo "#####################################################################"
     echo "### ERROR: Inconsistent formatting, please fix files and resubmit ###"
     echo "#####################################################################"
-    git diff --name-only | grep -E "^(src|test).*(.cpp$|.h)$" | xargs git diff
-    return 255
+    for i in ${CHANGED_FILES} ; do
+        git diff "${i}"
+    done
+    exit 255
 fi

--- a/.circleci/check-format.sh
+++ b/.circleci/check-format.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "Checking code format"
+if [ -n $(git diff --name-only | grep -E "^(src|test).*(.cpp$|.h)$") ] ; then
+    echo "#####################################################################"
+    echo "### ERROR: Inconsistent formatting, please fix files and resubmit ###"
+    echo "#####################################################################"
+    git diff --name-only | grep -E "^(src|test).*(.cpp$|.h)$" | xargs git diff
+    return 255
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,7 @@ jobs:
           command: mkdir build && cd build && cmake .. && make -j4 && make format
       - run:
           name: Check code format
-          command: |
-            if [ -n $(git diff --name-only | grep -E "^(src|test).*(.cpp$|.h)$") ] ; then \
-            echo "ERROR: Inconsistent formatting, please fix files and resubmit" ; \
-            git diff --name-only | grep -E "^(src|test).*(.cpp$|.h)$" | xargs git diff ; return 255 ;\
-            fi
+          command: .circleci/check-format.sh
       - run:
           name: extract Debian 9 libs for ubuntu 14.04 testrunner
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             cat .clang-tidy | grep WarningsAsErrors
       - run:
           name: build
-          command: mkdir build && cd build && cmake .. && make -j$(nproc) && make format
+          command: mkdir build && cd build && cmake .. && make -j4 && make format
       - run:
           name: Check code format
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,20 @@ jobs:
           name: checkout submodules
           command: git submodule update --init
       - run:
+          name: Fail on clang-tidy warnings
+          command: |
+            sed "s/WarningsAsErrors: ''/WarningsAsErrors: '*'/g" -i .clang-tidy && \
+            cat .clang-tidy | grep WarningsAsErrors
+      - run:
           name: build
-          command: mkdir build && cd build && cmake .. && make -j4
+          command: mkdir build && cd build && cmake .. && make -j$(nproc) && make format
+      - run:
+          name: Check code format
+          command: |
+            if [ -n $(git diff --name-only | grep -E "^(src|test).*(.cpp$|.h)$") ] ; then \
+            echo "ERROR: Inconsistent formatting, please fix files and resubmit" ; \
+            git diff --name-only | grep -E "^(src|test).*(.cpp$|.h)$" | xargs git diff ; return 255 ;\
+            fi
       - run:
           name: extract Debian 9 libs for ubuntu 14.04 testrunner
           command: |
@@ -47,8 +59,6 @@ jobs:
             for i in * ; do export DIR=$(echo $i|sed 's/_tests.xml//g') && mkdir ../$DIR ; cp $i ../$DIR ; done && \
             cd .. && \
             rm -Rf test
-          #ctest -T Test --output-on-failure || /bin/true && \
-          #xsltproc ../3rdparty/transform-test.xslt Testing/2*/*.xml > ../unittests/config-test/test.xml
       - store_test_results:
           path: /tmp/build/unittests
   smoke-test:

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,94 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: false
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*gtest/.*'
+    Priority:        2
+  - Regex:           '.*gmock/.*'
+    Priority:        2
+  - Regex:           '.*spdlog/.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,226 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,clang-analyzer-*,hicpp-*,google-*,boost-*,bugprone-*,cert-*,misc-*,modernize-*,llvm-*,readability-*,portability-*,performance-*,-readability-implicit-bool-conversion,-readability-braces-around-statements,-hicpp-braces-around-statements,-google-readability-braces-around-statements,-llvm-include-order,-clang-analyzer-alpha*'
+WarningsAsErrors: '*'
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+User:            maxf
+CheckOptions:    
+  - key:             bugprone-argument-comment.StrictMode
+    value:           '0'
+  - key:             bugprone-assert-side-effect.AssertMacros
+    value:           assert
+  - key:             bugprone-assert-side-effect.CheckFunctionCalls
+    value:           '0'
+  - key:             bugprone-dangling-handle.HandleClasses
+    value:           'std::basic_string_view;std::experimental::basic_string_view'
+  - key:             bugprone-string-constructor.LargeLengthThreshold
+    value:           '8388608'
+  - key:             bugprone-string-constructor.WarnOnLargeLength
+    value:           '1'
+  - key:             cert-dcl59-cpp.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             cert-err09-cpp.CheckThrowTemporaries
+    value:           '1'
+  - key:             cert-err61-cpp.CheckThrowTemporaries
+    value:           '1'
+  - key:             cert-oop11-cpp.IncludeStyle
+    value:           llvm
+  - key:             google-build-namespaces.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             google-global-names-in-headers.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             google-runtime-int.SignedTypePrefix
+    value:           int
+  - key:             google-runtime-int.TypeSuffix
+    value:           ''
+  - key:             google-runtime-int.UnsignedTypePrefix
+    value:           uint
+  - key:             google-runtime-references.WhiteListTypes
+    value:           ''
+  - key:             hicpp-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.StatementThreshold
+    value:           '800'
+  - key:             hicpp-member-init.IgnoreArrays
+    value:           '0'
+  - key:             hicpp-move-const-arg.CheckTriviallyCopyableMove
+    value:           '1'
+  - key:             hicpp-named-parameter.IgnoreFailedSplit
+    value:           '0'
+  - key:             hicpp-no-malloc.Allocations
+    value:           '::malloc;::calloc'
+  - key:             hicpp-no-malloc.Deallocations
+    value:           '::free'
+  - key:             hicpp-no-malloc.Reallocations
+    value:           '::realloc'
+  - key:             hicpp-special-member-functions.AllowMissingMoveFunctions
+    value:           '0'
+  - key:             hicpp-special-member-functions.AllowSoleDefaultDtor
+    value:           '0'
+  - key:             hicpp-use-auto.RemoveStars
+    value:           '0'
+  - key:             hicpp-use-emplace.ContainersWithPushBack
+    value:           '::std::vector;::std::list;::std::deque'
+  - key:             hicpp-use-emplace.SmartPointers
+    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  - key:             hicpp-use-emplace.TupleMakeFunctions
+    value:           '::std::make_pair;::std::make_tuple'
+  - key:             hicpp-use-emplace.TupleTypes
+    value:           '::std::pair;::std::tuple'
+  - key:             hicpp-use-equals-default.IgnoreMacros
+    value:           '1'
+  - key:             hicpp-use-noexcept.ReplacementString
+    value:           ''
+  - key:             hicpp-use-noexcept.UseNoexceptFalse
+    value:           '1'
+  - key:             hicpp-use-nullptr.NullMacros
+    value:           ''
+  - key:             llvm-namespace-comment.ShortNamespaceLines
+    value:           '1'
+  - key:             llvm-namespace-comment.SpacesBeforeComments
+    value:           '1'
+  - key:             misc-definitions-in-headers.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             misc-definitions-in-headers.UseHeaderFileExtension
+    value:           '1'
+  - key:             misc-misplaced-widening-cast.CheckImplicitCasts
+    value:           '0'
+  - key:             misc-sizeof-expression.WarnOnSizeOfCompareToConstant
+    value:           '1'
+  - key:             misc-sizeof-expression.WarnOnSizeOfConstant
+    value:           '1'
+  - key:             misc-sizeof-expression.WarnOnSizeOfThis
+    value:           '1'
+  - key:             misc-suspicious-enum-usage.StrictMode
+    value:           '0'
+  - key:             misc-suspicious-missing-comma.MaxConcatenatedTokens
+    value:           '5'
+  - key:             misc-suspicious-missing-comma.RatioThreshold
+    value:           '0.200000'
+  - key:             misc-suspicious-missing-comma.SizeThreshold
+    value:           '5'
+  - key:             misc-suspicious-string-compare.StringCompareLikeFunctions
+    value:           ''
+  - key:             misc-suspicious-string-compare.WarnOnImplicitComparison
+    value:           '1'
+  - key:             misc-suspicious-string-compare.WarnOnLogicalNotComparison
+    value:           '0'
+  - key:             misc-throw-by-value-catch-by-reference.CheckThrowTemporaries
+    value:           '1'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-make-shared.IgnoreMacros
+    value:           '1'
+  - key:             modernize-make-shared.IncludeStyle
+    value:           '0'
+  - key:             modernize-make-shared.MakeSmartPtrFunction
+    value:           'std::make_shared'
+  - key:             modernize-make-shared.MakeSmartPtrFunctionHeader
+    value:           memory
+  - key:             modernize-make-unique.IgnoreMacros
+    value:           '1'
+  - key:             modernize-make-unique.IncludeStyle
+    value:           '0'
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'std::make_unique'
+  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:           memory
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-pass-by-value.ValuesOnly
+    value:           '0'
+  - key:             modernize-raw-string-literal.ReplaceShorterLiterals
+    value:           '0'
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-random-shuffle.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-auto.RemoveStars
+    value:           '0'
+  - key:             modernize-use-default-member-init.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           '0'
+  - key:             modernize-use-emplace.ContainersWithPushBack
+    value:           '::std::vector;::std::list;::std::deque'
+  - key:             modernize-use-emplace.SmartPointers
+    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  - key:             modernize-use-emplace.TupleMakeFunctions
+    value:           '::std::make_pair;::std::make_tuple'
+  - key:             modernize-use-emplace.TupleTypes
+    value:           '::std::pair;::std::tuple'
+  - key:             modernize-use-equals-default.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-noexcept.ReplacementString
+    value:           ''
+  - key:             modernize-use-noexcept.UseNoexceptFalse
+    value:           '1'
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             modernize-use-transparent-functors.SafeMode
+    value:           '0'
+  - key:             modernize-use-using.IgnoreMacros
+    value:           '1'
+  - key:             performance-faster-string-find.StringLikeClasses
+    value:           'std::basic_string'
+  - key:             performance-for-range-copy.WarnOnAllAutoCopies
+    value:           '0'
+  - key:             performance-inefficient-string-concatenation.StrictMode
+    value:           '0'
+  - key:             performance-inefficient-vector-operation.VectorLikeClasses
+    value:           '::std::vector'
+  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
+    value:           '1'
+  - key:             performance-move-constructor-init.IncludeStyle
+    value:           llvm
+  - key:             performance-type-promotion-in-math-fn.IncludeStyle
+    value:           llvm
+  - key:             performance-unnecessary-value-param.IncludeStyle
+    value:           llvm
+  - key:             readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             readability-identifier-naming.IgnoreFailedSplit
+    value:           '0'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalAssignment
+    value:           '0'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalReturn
+    value:           '0'
+  - key:             readability-static-accessed-through-instance.NameSpecifierNestingThreshold
+    value:           '3'
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,clang-analyzer-*,hicpp-*,google-*,boost-*,bugprone-*,cert-*,misc-*,modernize-*,llvm-*,readability-*,portability-*,performance-*,-readability-implicit-bool-conversion,-readability-braces-around-statements,-hicpp-braces-around-statements,-google-readability-braces-around-statements,-llvm-include-order,-clang-analyzer-alpha*'
-WarningsAsErrors: '*'
+Checks:          '-*,boost-*,bugprone-*,cert-*,cppcoreguidelines-*,clang-*,fuchsia-*,google-*,hicpp-*,llvm-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-readability-implicit-bool-conversion,-hicpp-braces-around-statements,-google-readability-braces-around-statements,-fuchsia-default-arguments,-cppcoreguidelines-pro-type-vararg,-llvm-include-order,-zircon,-cppcoreguidelines-pro-bounds-constant-array-index,-clang-analyzer-alpha*'
+WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     none

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,16 @@ cmake_minimum_required(VERSION 3.7.2)
 project(cinit)
 
 set(CMAKE_CXX_STANDARD 14)
-IF (${CMAKE_VERSION} VERSION_LESS "3.9.0")
+if (${CMAKE_VERSION} VERSION_LESS "3.9.0")
     set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/cmake)
-ENDIF()
+endif()
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug)
+    message(STATUS "No build type specified, defaulting to Debug")
+endif()
+if (CMAKE_BUILD_TYPE MATCHES Debug)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -Werror")
+endif()
 include(GoogleTest)
 enable_testing()
 
@@ -36,14 +43,43 @@ set(SCINIT_SOURCE_FILES ChildProcess.cpp ChildProcess.h Config.h ConfigParseExce
 foreach(source ${SCINIT_SOURCE_FILES})
     list(APPEND ABS_SCINIT_SOURCE_FILES ${PROJECT_SOURCE_DIR}/src/${source})
 endforeach()
+# All source files - used for clang-format
+#set(ALL_SOURCE_FILES ${ABS_SCINIT_SOURCE_FILES})
 
 # Add GTest here, since we need 'gtest_prod.h' in src/
 add_subdirectory(3rdparty/googletest gtest-build EXCLUDE_FROM_ALL)
 target_include_directories(gmock_main SYSTEM BEFORE INTERFACE
         "${gtest_SOURCE_DIR}/include" "${gmock_SOURCE_DIR}/include")
 
+# Clang-tidy
+# TODO(uubk): hicpp-braces-around-statements
+find_program(CLANG_TIDY NAMES clang-tidy-6.0 clang-tidy-5.0 clang-tidy-3.9 clang-tidy-3.8  clang-tidy)
+if(NOT CLANG_TIDY)
+    message(WARNING "clang-tidy not found, checks will not be performed!")
+else()
+    message(STATUS "clang-tidy found: ${CLANG_TIDY}, buildtype: ${CMAKE_BUILD_TYPE}")
+    set(CLANG_TIDY_ARGS "${CLANG_TIDY}")
+endif()
+
 # Main source
 add_subdirectory(src)
 
 # Tests
 add_subdirectory(test)
+
+# Clang-format
+file(GLOB_RECURSE SCINIT_TEST_SOURCE_FILES_CPP test/*.cpp)
+file(GLOB_RECURSE SCINIT_TEST_SOURCE_FILES_H test/*.h)
+file(GLOB_RECURSE SCINIT_MAIN_SOURCE_FILES_CPP src/*.cpp)
+file(GLOB_RECURSE SCINIT_MAIN_SOURCE_FILES_H src/*.h)
+
+set(ALL_SOURCE_FILES ${SCINIT_TEST_SOURCE_FILES_CPP} ${SCINIT_TEST_SOURCE_FILES_H} ${SCINIT_MAIN_SOURCE_FILES_CPP}
+        ${SCINIT_MAIN_SOURCE_FILES_H})
+
+add_custom_target(
+        format
+        COMMAND /usr/bin/clang-format
+        -style=file
+        -i
+        ${ALL_SOURCE_FILES}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ endif()
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -Werror")
 endif()
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 include(GoogleTest)
 enable_testing()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,3 +18,7 @@
 add_executable(scinit main.cpp ${SCINIT_SOURCE_FILES})
 # Link gtest. We won't use any symbols but the dependency makes the includes available...
 target_link_libraries(scinit yaml-cpp pthread cap gtest_main ${Boost_LIBRARIES})
+if (CLANG_TIDY AND CMAKE_BUILD_TYPE MATCHES Debug)
+    message(STATUS "clang-tidy enabled for scinit")
+    set_target_properties(scinit PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_ARGS}")
+endif()

--- a/src/ChildProcess.cpp
+++ b/src/ChildProcess.cpp
@@ -34,7 +34,7 @@ namespace scinit {
                                std::list<std::string> before, std::list<std::string> after)
       : name(std::move(name)), path(std::move(path)), args(std::move(args)), capabilities(std::move(capabilities)),
         uid(uid), gid(gid), graph_id(graph_id), handler(handler), before(std::move(before)), after(std::move(after)) {
-        if (before.empty() && after.empty()) {
+        if (this->before.empty() && this->after.empty()) {
             this->state = READY;
         } else {
             this->state = BLOCKED;

--- a/src/ChildProcess.cpp
+++ b/src/ChildProcess.cpp
@@ -14,28 +14,26 @@
  * limitations under the License.
  */
 
-#include <unistd.h>
+#include "ChildProcess.h"
 #include <fcntl.h>
 #include <sys/capability.h>
-#include <sys/prctl.h>
 #include <sys/epoll.h>
+#include <sys/prctl.h>
+#include <unistd.h>
+#include <cstring>
 #include <iostream>
 #include <memory>
-#include <cstring>
 #include <numeric>
-#include "log.h"
-#include "ChildProcess.h"
 #include "ChildProcessException.h"
+#include "log.h"
 
 namespace scinit {
-    ChildProcess::ChildProcess(const std::string &name, const std::string &path, const std::list<std::string>& args,
-                               const std::string &type, const std::list<std::string> &capabilities, unsigned int uid,
-                               unsigned int gid, unsigned int graph_id,
-                               std::shared_ptr<ProcessHandlerInterface> handler, const std::list<std::string> &before,
-                               const std::list<std::string> &after) : path(path), args(args), name(name),
-                                                                      capabilities(capabilities), uid(uid), gid(gid),
-                                                                      graph_id(graph_id), handler(handler),
-                                                                      before(before), after(after) {
+    ChildProcess::ChildProcess(std::string name, std::string path, std::list<std::string> args, const std::string& type,
+                               std::list<std::string> capabilities, unsigned int uid, unsigned int gid,
+                               unsigned int graph_id, const std::shared_ptr<ProcessHandlerInterface>& handler,
+                               std::list<std::string> before, std::list<std::string> after)
+      : name(std::move(name)), path(std::move(path)), args(std::move(args)), capabilities(std::move(capabilities)),
+        uid(uid), gid(gid), graph_id(graph_id), handler(handler), before(std::move(before)), after(std::move(after)) {
         if (before.empty() && after.empty())
             this->state = READY;
         else
@@ -47,21 +45,18 @@ namespace scinit {
             this->type = ONESHOT;
         }
 
-        auto ref = std::bind(&ChildProcess::handle_process_event, this,
-                std::placeholders::_1, std::placeholders::_2);
+        auto ref = std::bind(&ChildProcess::handle_process_event, this, std::placeholders::_1, std::placeholders::_2);
         handler->register_for_process_state(graph_id, ref);
     }
 
-    unsigned int ChildProcess::get_id() const noexcept {
-        return graph_id;
-    }
+    unsigned int ChildProcess::get_id() const noexcept { return graph_id; }
 
     void ChildProcess::handle_caps() {
         // Step 1: Make sure that the this process has all caps that we need
         std::string cap_string = "CAP_SETUID=eip CAP_SETGID=eip CAP_SETPCAP=eip";
         cap_t new_caps_transitional;
-        for (const auto & capability: capabilities)
-            cap_string += " "+capability+"=eip";
+        for (const auto& capability : capabilities)
+            cap_string += " " + capability + "=eip";
         const char* c_cap_string = cap_string.c_str();
         new_caps_transitional = cap_from_text(c_cap_string);
 
@@ -71,12 +66,14 @@ namespace scinit {
         }
 
         // Keep caps across setuid because otherwise we can't set ambient caps below
+        // NOLINTNEXTLINE(hicpp-vararg)
         prctl(PR_SET_KEEPCAPS, 1);
         // Set user and group
         if (setgid(this->gid) == -1)
             std::cerr << "Couldn't set group!" << std::endl;
         if (setuid(this->uid) == -1)
             std::cerr << "Couldn't set user!" << std::endl;
+        // NOLINTNEXTLINE(hicpp-vararg)
         prctl(PR_SET_KEEPCAPS, 0);
 
         rc = cap_set_proc(new_caps_transitional);
@@ -86,15 +83,17 @@ namespace scinit {
 
         // Step 2: Make sure that the child process only retains the capabilities explicitly specified
         // Clear all ambient capabielities and
+        // NOLINTNEXTLINE(hicpp-vararg)
         prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0);
         // ... re-add those we need explicitly
         cap_string = "";
-        for (const auto & capability: capabilities) {
-            cap_string += " "+capability+"=eip";
+        for (const auto& capability : capabilities) {
+            cap_string += " " + capability + "=eip";
             cap_value_t cap = {};
             if (cap_from_name(capability.c_str(), &cap) != 0) {
                 std::cerr << "Warning: Couldn't decode '" << capability << "', not adding to set." << std::endl;
             }
+            // NOLINTNEXTLINE(hicpp-vararg)
             if (prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, cap, 0, 0) != -1) {
                 std::cout << "Ambient capability '" << capability << "' enabled." << std::endl;
             } else {
@@ -113,19 +112,20 @@ namespace scinit {
          * */
         c_cap_string = cap_string.c_str();
         auto new_caps = cap_from_text(c_cap_string);
-        rc = cap_set_proc(new_caps_transitional);
+        rc = cap_set_proc(new_caps);
         if (rc != 0) {
             std::cerr << "Couldn't set capabilities, some features might not work as intended!" << std::endl;
         }
     }
 
-    void ChildProcess::do_fork(std::map<int, int>& reg) noexcept(false) {
+    void ChildProcess::do_fork(std::map<int, unsigned int>& reg) noexcept(false) {
         if (state != READY)
             throw ChildProcessException("Process not ready, cannot fork now!");
 
-        if (pipe(stdouterr) == -1) {
+        if (pipe(static_cast<int*>(stdouterr)) == -1) {
             throw ChildProcessException("Couldn't create pipe!");
         }
+        // NOLINTNEXTLINE(hicpp-vararg)
         fcntl(stdouterr[0], FD_CLOEXEC);
 
         primaryPid = fork();
@@ -134,18 +134,20 @@ namespace scinit {
             // Note: This block will never return
 
             // Redirect stdout and stderr to pipe
-            while (dup2(stdouterr[1], STDOUT_FILENO) == -1 && errno == EINTR) {}
-            while (dup2(stdouterr[1], STDERR_FILENO) == -1 && errno == EINTR) {}
+            while (dup2(stdouterr[1], STDOUT_FILENO) == -1 && errno == EINTR) {
+            }
+            while (dup2(stdouterr[1], STDERR_FILENO) == -1 && errno == EINTR) {
+            }
             close(stdouterr[1]);
 
             // Transform args
             const char* program = this->path.c_str();
-            char *c_args[this->args.size()+2];
+            auto c_args = new char*[this->args.size() + 2];
             int i = 1;
             c_args[0] = const_cast<char*>(program);
-            for (auto& arg : this->args){
-                auto buf = new char[arg.length()+1];
-                std::strcpy(buf, arg.c_str());
+            for (auto& arg : this->args) {
+                auto buf = new char[arg.length() + 1];
+                std::strncpy(buf, arg.c_str(), arg.length());
                 c_args[i] = buf;
                 i++;
             }
@@ -155,7 +157,7 @@ namespace scinit {
             handle_caps();
 
             // Execute program
-            int retval = execvp(program, c_args);
+            int retval = execvp(program, static_cast<char* const*>(c_args));
 
             // If we get to this point something went wrong...
             LOG->critical("Could not exec child process: {0}", retval);
@@ -167,8 +169,8 @@ namespace scinit {
         reg[primaryPid] = graph_id;
     }
 
-    void ChildProcess::register_with_epoll(int epoll_fd, std::map<int, int>& map) noexcept(false) {
-        struct epoll_event setup{};
+    void ChildProcess::register_with_epoll(int epoll_fd, std::map<int, unsigned int>& map) noexcept(false) {
+        struct epoll_event setup {};
         setup.data.fd = stdouterr[0];
         setup.events = EPOLLIN;
         if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, stdouterr[0], &setup) == -1) {
@@ -177,79 +179,71 @@ namespace scinit {
         map[stdouterr[0]] = graph_id;
     }
 
-    std::string ChildProcess::get_name() const noexcept {
-        return name;
-    }
+    std::string ChildProcess::get_name() const noexcept { return name; }
 
-    bool ChildProcess::can_start_now() const noexcept {
-        return state == READY;
-    }
+    bool ChildProcess::can_start_now() const noexcept { return state == READY; }
 
-    void ChildProcess::should_wait_for(int other_process, ProcessState other_state) noexcept {
-        bool contains = std::accumulate(conditions.begin(), conditions.end(), false, [other_process](bool contains,
-                auto pair) {
-            if (contains)
-                return true;
-            if (pair.first == other_process)
-                return true;
-            return false;
-        });
+    void ChildProcess::should_wait_for(unsigned int other_process, ProcessState other_state) noexcept {
+        bool contains =
+          std::accumulate(conditions.begin(), conditions.end(), false, [other_process](bool contains, auto pair) {
+              if (contains)
+                  return true;
+              if (pair.first == other_process)
+                  return true;
+              return false;
+          });
         if (!contains)
-            conditions.push_back(std::make_pair(other_process, other_state));
+            conditions.emplace_back(std::make_pair(other_process, other_state));
     }
 
-    void ChildProcess::propagate_dependencies(std::list<std::weak_ptr<scinit::ChildProcessInterface>> other_processes)
-            noexcept {
-        auto func = [&other_processes, classref=this](auto dependency, bool other_or_this) {
+    void ChildProcess::propagate_dependencies(
+      std::list<std::weak_ptr<scinit::ChildProcessInterface>> other_processes) noexcept {
+        auto func = [&other_processes, classref = this](auto dependency, bool other_or_this) {
             for (const auto& weak_ref : other_processes) {
                 if (auto ref = weak_ref.lock()) {
                     if (ref->get_name() == dependency) {
                         if (other_or_this)
-                            ref->should_wait_for(classref->graph_id, classref->type==SIMPLE ? ProcessState::DONE :
-                                                 ProcessState::RUNNING);
+                            ref->should_wait_for(classref->graph_id,
+                                                 classref->type == SIMPLE ? ProcessState::DONE : ProcessState::RUNNING);
                         else
-                            classref->should_wait_for(ref->get_id(), classref->type==SIMPLE ? ProcessState::DONE :
-                                                      ProcessState::RUNNING);
+                            classref->should_wait_for(
+                              ref->get_id(), classref->type == SIMPLE ? ProcessState::DONE : ProcessState::RUNNING);
                     }
                 }
             }
         };
-        std::for_each(before.begin(), before.end(), [&func, this](auto arg){func(arg, true);});
-        std::for_each(after.begin(), after.end(), [&func, this](auto arg){func(arg, false);});
+        std::for_each(before.begin(), before.end(), [&func, this](auto arg) { func(arg, true); });
+        std::for_each(after.begin(), after.end(), [&func, this](auto arg) { func(arg, false); });
         before.clear();
         after.clear();
     }
 
-    ChildProcessInterface::ProcessState ChildProcess::get_state() const noexcept {
-        return state;
-    }
+    ChildProcessInterface::ProcessState ChildProcess::get_state() const noexcept { return state; }
 
-    void ChildProcess::notify_of_state(std::map<unsigned int, std::weak_ptr<ChildProcessInterface>> other_procs)
-                                        noexcept {
+    void ChildProcess::notify_of_state(
+      std::map<unsigned int, std::weak_ptr<ChildProcessInterface>> other_procs) noexcept {
         if (state == BLOCKED) {
-            bool still_blocked = std::accumulate(conditions.begin(), conditions.end(), false, [&other_procs, this]
-                    (bool blocked, auto condition) {
-                if (blocked)
-                    return true;
-                else {
-                    if (!other_procs.count(condition.first)) {
-                        LOG->critical("BUG: Found reference to process that doesn't exist");
-                        return true;
-                    } else if (auto ptr = other_procs[condition.first].lock()) {
-                        return ptr->get_state() != condition.second;
-                    } else {
-                        LOG->critical("BUG: Found reference to process that doesn't exist anymore");
-                        return true;
-                    }
-                }
-            });
+            bool still_blocked = std::accumulate(
+              conditions.begin(), conditions.end(), false, [&other_procs, this](bool blocked, auto condition) {
+                  if (blocked)
+                      return true;
+                  if (!other_procs.count(condition.first)) {
+                      LOG->critical("BUG: Found reference to process that doesn't exist");
+                      return true;
+                  }
+                  if (auto ptr = other_procs[condition.first].lock()) {
+                      return ptr->get_state() != condition.second;
+                  }
+                  LOG->critical("BUG: Found reference to process that doesn't exist anymore");
+                  return true;
+              });
             if (!still_blocked)
                 state = READY;
         }
     }
 
     void ChildProcess::handle_process_event(ProcessHandlerInterface::ProcessEvent event, int data) noexcept {
-        switch(event){
+        switch (event) {
             case ProcessHandlerInterface::ProcessEvent::SIGHUP:
                 break;
             case ProcessHandlerInterface::ProcessEvent::EXIT:
@@ -263,4 +257,4 @@ namespace scinit {
                 break;
         }
     }
-}
+}  // namespace scinit

--- a/src/ChildProcess.h
+++ b/src/ChildProcess.h
@@ -36,6 +36,7 @@ namespace scinit {
 
         ChildProcess(const ChildProcess &) = delete;
         virtual ChildProcess &operator=(const ChildProcess &) = delete;
+        virtual ~ChildProcess() = default;
 
         void do_fork(std::map<int, unsigned int> &) noexcept(false) override;
         void register_with_epoll(int, std::map<int, unsigned int> &) noexcept(false) override;

--- a/src/ChildProcess.h
+++ b/src/ChildProcess.h
@@ -17,48 +17,47 @@
 #ifndef CINIT_CHILDPROCESS_H
 #define CINIT_CHILDPROCESS_H
 
-#include <string>
+#include "gtest/gtest_prod.h"
 #include <list>
 #include <map>
-#include "gtest/gtest_prod.h"
-#include "ProcessHandlerInterface.h"
+#include <string>
 #include "ChildProcessInterface.h"
+#include "ProcessHandlerInterface.h"
 
 namespace scinit {
     class ProcessLifecycleTests;
 
     // See base class for documentation
     class ChildProcess : public ChildProcessInterface {
-    public:
-        ChildProcess(const std::string&, const std::string &, const std::list<std::string> &, const std::string &,
-                     const std::list<std::string> &, unsigned int, unsigned int, unsigned int,
-                     std::shared_ptr<ProcessHandlerInterface>, const std::list<std::string> &,
-                     const std::list<std::string> &);
+      public:
+        ChildProcess(std::string, std::string, std::list<std::string>, const std::string &, std::list<std::string>,
+                     unsigned int, unsigned int, unsigned int, const std::shared_ptr<ProcessHandlerInterface> &,
+                     std::list<std::string>, std::list<std::string>);
 
-        ChildProcess(const ChildProcess&) = delete;
-        virtual ChildProcess& operator=(const ChildProcess&) = delete;
+        ChildProcess(const ChildProcess &) = delete;
+        virtual ChildProcess &operator=(const ChildProcess &) = delete;
 
-        void do_fork(std::map<int, int>&) noexcept(false) override;
-        void register_with_epoll(int, std::map<int, int>&) noexcept(false) override;
+        void do_fork(std::map<int, unsigned int> &) noexcept(false) override;
+        void register_with_epoll(int, std::map<int, unsigned int> &) noexcept(false) override;
         std::string get_name() const noexcept override;
         unsigned int get_id() const noexcept override;
         bool can_start_now() const noexcept override;
         void notify_of_state(std::map<unsigned int, std::weak_ptr<ChildProcessInterface>>) noexcept override;
         void propagate_dependencies(std::list<std::weak_ptr<ChildProcessInterface>>) noexcept override;
-        void should_wait_for(int, ProcessState) noexcept override;
+        void should_wait_for(unsigned int, ProcessState) noexcept override;
         void handle_process_event(ProcessHandlerInterface::ProcessEvent event, int data) noexcept override;
-        ProcessState get_state() const noexcept override ;
+        ProcessState get_state() const noexcept override;
 
-    private:
-        std::string path, name;
-        std::list<std::string> args, capabilities, before, after;
-        std::list<std::pair<unsigned int, ChildProcessInterface::ProcessState>> conditions;
+      private:
+        std::string name, path;
+        std::list<std::string> args, capabilities;
         unsigned int uid, gid, graph_id;
-        int stdouterr[2], primaryPid;
+        std::shared_ptr<ProcessHandlerInterface> handler;
+        std::list<std::string> before, after;
+        std::list<std::pair<unsigned int, ChildProcessInterface::ProcessState>> conditions;
+        int stdouterr[2] = {-1, -1}, primaryPid = -1;
         ProcessType type;
         ProcessState state;
-        std::shared_ptr<ProcessHandlerInterface> handler;
-
         void handle_caps();
 
         FRIEND_TEST(ConfigParserTests, SmokeTestConfig);
@@ -68,6 +67,6 @@ namespace scinit {
         FRIEND_TEST(ProcessLifecycleTests, TwoDependantProcessesLifecycle);
         friend class ProcessLifecycleTests;
     };
-}
+}  // namespace scinit
 
-#endif //CINIT_CHILDPROCESS_H
+#endif  // CINIT_CHILDPROCESS_H

--- a/src/ChildProcessException.cpp
+++ b/src/ChildProcessException.cpp
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-#include <string>
 #include "ChildProcessException.h"
+#include <string>
 
 namespace scinit {
-    ChildProcessException::ChildProcessException(const char* what) noexcept {
-        this->reason = std::string(what);
-    }
+    ChildProcessException::ChildProcessException(const char* what) noexcept { this->reason = std::string(what); }
 
-    const char* ChildProcessException::what() const noexcept {
-        return this->reason.c_str();
-    }
-}
+    const char* ChildProcessException::what() const noexcept { return this->reason.c_str(); }
+}  // namespace scinit

--- a/src/ChildProcessException.h
+++ b/src/ChildProcessException.h
@@ -18,16 +18,17 @@
 #define CINIT_CHILDPROCESSEXCEPTION_H
 
 #include <exception>
+#include <string>
 
 namespace scinit {
     class ChildProcessException : virtual std::exception {
-    public:
-        explicit ChildProcessException(const char* reason) noexcept;
+      public:
+        explicit ChildProcessException(const char*) noexcept;
         const char* what() const noexcept override;
 
-    private:
+      private:
         std::string reason;
     };
-}
+}  // namespace scinit
 
-#endif //CINIT_CHILDPROCESSEXCEPTION_H
+#endif  // CINIT_CHILDPROCESSEXCEPTION_H

--- a/src/ChildProcessInterface.h
+++ b/src/ChildProcessInterface.h
@@ -17,13 +17,13 @@
 #ifndef CINIT_CHILDPROCESSINTERFACE_H
 #define CINIT_CHILDPROCESSINTERFACE_H
 
-#include <string>
 #include <list>
+#include <string>
 #include "ProcessHandler.h"
 
 namespace scinit {
     class ChildProcessInterface : public std::enable_shared_from_this<ChildProcessInterface> {
-    public:
+      public:
         ChildProcessInterface() = default;
         // Do not copy ;)
         ChildProcessInterface(const ChildProcessInterface&) = delete;
@@ -46,17 +46,10 @@ namespace scinit {
          * At some point, CRASHED processes should move (possibly via backoff) to READY so that they can be started
          * again.
          */
-        enum ProcessState {
-            BLOCKED,
-            READY,
-            RUNNING,
-            DONE,
-            CRASHED,
-            BACKOFF
-        };
+        enum ProcessState { BLOCKED, READY, RUNNING, DONE, CRASHED, BACKOFF };
 
         // Fork, and register the pid to the current object
-        virtual void do_fork(std::map<int, int>&) = 0;
+        virtual void do_fork(std::map<int, unsigned int>&) = 0;
 
         virtual std::string get_name() const = 0;
         virtual unsigned int get_id() const = 0;
@@ -66,7 +59,7 @@ namespace scinit {
          * In order to handle stdout/stderr forwarding, the pipe needs to be registered with epoll,
          * which is what this function does. It also registers the fd to the current object.
          */
-        virtual void register_with_epoll(int epollfd, std::map<int, int>& fd_to_obj) = 0;
+        virtual void register_with_epoll(int epollfd, std::map<int, unsigned int>& fd_to_obj) = 0;
 
         /*
          * This function is called by the process handler with a list of all existing processes as an argument.
@@ -83,7 +76,7 @@ namespace scinit {
         /*
          * This function is called by another process if we need to wait for it to reach a certain state.
          * */
-        virtual void should_wait_for(int, ProcessState) = 0;
+        virtual void should_wait_for(unsigned int, ProcessState) = 0;
 
         /*
          * Handle a process event. This function is called from the process handler and deals with process state
@@ -93,7 +86,6 @@ namespace scinit {
 
         virtual ProcessState get_state() const = 0;
     };
-}
+}  // namespace scinit
 
-#endif //CINIT_CHILDPROCESSINTERFACE_H
-
+#endif  // CINIT_CHILDPROCESSINTERFACE_H

--- a/src/ChildProcessInterface.h
+++ b/src/ChildProcessInterface.h
@@ -28,6 +28,7 @@ namespace scinit {
         // Do not copy ;)
         ChildProcessInterface(const ChildProcessInterface&) = delete;
         virtual ChildProcessInterface& operator=(const ChildProcessInterface&) = delete;
+        virtual ~ChildProcessInterface() = default;
 
         /*
          * What kind of process is this? ONESHOT is for programs that do something and then exit and should not be

--- a/src/Config.h
+++ b/src/Config.h
@@ -41,8 +41,9 @@ namespace scinit {
       public:
         Config(const std::string& path, std::shared_ptr<ProcessHandlerInterface> handler) noexcept(false)
           : handler(handler) {
-            if (fs::is_directory(fs::path(path)))
+            if (fs::is_directory(fs::path(path))) {
                 throw ConfigParseException("This constructor is for single files only!");
+            }
             load_file(path);
             LOG->info("Config loaded");
         }
@@ -54,6 +55,8 @@ namespace scinit {
             }
             LOG->info("Config loaded");
         }
+
+        ~Config() override = default;
 
         std::list<std::weak_ptr<CTYPE>> get_processes() const noexcept override {
             return std::accumulate(processes.begin(), processes.end(), std::list<std::weak_ptr<CTYPE>>(),
@@ -70,8 +73,9 @@ namespace scinit {
         void load_file(const std::string& file) noexcept(false) {
             auto root = YAML::LoadFile(file);
 
-            if (!root["programs"])
+            if (!root["programs"]) {
                 throw ConfigParseException("Config file is missing the 'programs' node!");
+            }
 
             LOG->debug("Dump\n{0}", root);
             parse_file(root);
@@ -81,8 +85,9 @@ namespace scinit {
             std::list<std::string> list;
             if ((*root)[node_name]) {
                 YAML::Node node = (*root)[node_name];
-                for (auto str : node)
+                for (auto str : node) {
                     list.push_back(str.as<std::string>());
+                }
             }
             return std::move(list);
         }

--- a/src/Config.h
+++ b/src/Config.h
@@ -17,15 +17,15 @@
 #ifndef CINIT_CONFIG_H
 #define CINIT_CONFIG_H
 
-#include <boost/program_options.hpp>
-#include <boost/filesystem.hpp>
 #include <yaml-cpp/yaml.h>
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
 #include <iostream>
 #include <numeric>
-#include "ConfigInterface.h"
-#include "Config.h"
-#include "ConfigParseException.h"
 #include "ChildProcess.h"
+#include "Config.h"
+#include "ConfigInterface.h"
+#include "ConfigParseException.h"
 #include "ProcessHandler.h"
 #include "log.h"
 
@@ -36,18 +36,19 @@ namespace scinit {
     class ProcessHandlerInterface;
 
     // See base class for documentation
-    template <class CTYPE> class Config : public ConfigInterface<CTYPE> {
-    public:
-        Config(const std::string &path, std::shared_ptr<ProcessHandlerInterface> handler) noexcept(false) :
-                handler(handler) {
+    template <class CTYPE>
+    class Config : public ConfigInterface<CTYPE> {
+      public:
+        Config(const std::string& path, std::shared_ptr<ProcessHandlerInterface> handler) noexcept(false)
+          : handler(handler) {
             if (fs::is_directory(fs::path(path)))
                 throw ConfigParseException("This constructor is for single files only!");
             load_file(path);
             LOG->info("Config loaded");
         }
 
-        Config(const std::list<std::string> &files, std::shared_ptr<ProcessHandlerInterface> handler) noexcept(false) :
-                handler(handler) {
+        Config(const std::list<std::string>& files, std::shared_ptr<ProcessHandlerInterface> handler) noexcept(false)
+          : handler(handler) {
             for (auto file : files) {
                 load_file(file);
             }
@@ -55,16 +56,17 @@ namespace scinit {
         }
 
         std::list<std::weak_ptr<CTYPE>> get_processes() const noexcept override {
-            return std::accumulate(processes.begin(), processes.end(), std::list<std::weak_ptr<CTYPE>>(), [](auto list, auto ptr){
-                list.push_back(ptr);
-                return list;
-            });
+            return std::accumulate(processes.begin(), processes.end(), std::list<std::weak_ptr<CTYPE>>(),
+                                   [](auto list, auto ptr) {
+                                       list.push_back(ptr);
+                                       return list;
+                                   });
         }
 
         Config(const Config&) = delete;
         virtual Config& operator=(const Config&) = delete;
 
-    private:
+      private:
         void load_file(const std::string& file) noexcept(false) {
             auto root = YAML::LoadFile(file);
 
@@ -85,7 +87,7 @@ namespace scinit {
             return std::move(list);
         }
 
-        void parse_file(const YAML::Node & rootNode) {
+        void parse_file(const YAML::Node& rootNode) {
             YAML::Node programs = rootNode["programs"];
             for (auto program = programs.begin(); program != programs.end(); program++) {
                 if (!(*program)["name"]) {
@@ -104,9 +106,9 @@ namespace scinit {
                 }
 
                 std::list<std::string> arg_list = yaml_node_to_str_list(program, "args"),
-                        capabilities = yaml_node_to_str_list(program, "capabilities"),
-                        before = yaml_node_to_str_list(program, "before"),
-                        after = yaml_node_to_str_list(program, "after");
+                                       capabilities = yaml_node_to_str_list(program, "capabilities"),
+                                       before = yaml_node_to_str_list(program, "before"),
+                                       after = yaml_node_to_str_list(program, "after");
 
                 int uid = 65534, gid = 65534;
                 if ((*program)["uid"]) {
@@ -117,8 +119,8 @@ namespace scinit {
                 }
 
                 auto process = std::make_shared<ChildProcess>(
-                        (*program)["name"].as<std::string>(),(*program)["path"].as<std::string>(), arg_list, type,
-                        capabilities, uid, gid, child_counter++, handler, before, after);
+                  (*program)["name"].as<std::string>(), (*program)["path"].as<std::string>(), arg_list, type,
+                  capabilities, uid, gid, child_counter++, handler, before, after);
                 processes.push_back(process);
                 handler->register_obj_id(process->get_id(), process);
             }
@@ -128,6 +130,6 @@ namespace scinit {
         int child_counter = 0;
         std::shared_ptr<ProcessHandlerInterface> handler;
     };
-}
+}  // namespace scinit
 
-#endif //CINIT_CONFIG_H
+#endif  // CINIT_CONFIG_H

--- a/src/ConfigInterface.h
+++ b/src/ConfigInterface.h
@@ -27,6 +27,7 @@ namespace scinit {
     class ConfigInterface {
       public:
         ConfigInterface() = default;
+        virtual ~ConfigInterface() = default;
 
         // No copy
         ConfigInterface(const ConfigInterface&) = delete;

--- a/src/ConfigInterface.h
+++ b/src/ConfigInterface.h
@@ -17,14 +17,15 @@
 #ifndef CINIT_CONFIGINTERFACE_H
 #define CINIT_CONFIGINTERFACE_H
 
-#include <memory>
 #include <list>
+#include <memory>
 
 namespace scinit {
     class ChildProcessInterface;
 
-    template <class CTYPE> class ConfigInterface {
-    public:
+    template <class CTYPE>
+    class ConfigInterface {
+      public:
         ConfigInterface() = default;
 
         // No copy
@@ -34,7 +35,6 @@ namespace scinit {
         // Get a list of _all_ processes
         virtual std::list<std::weak_ptr<CTYPE>> get_processes() const noexcept = 0;
     };
-}
+}  // namespace scinit
 
-
-#endif //CINIT_CONFIGINTERFACE_H
+#endif  // CINIT_CONFIGINTERFACE_H

--- a/src/ConfigParseException.cpp
+++ b/src/ConfigParseException.cpp
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-#include <string>
 #include "ConfigParseException.h"
+#include <string>
 
 namespace scinit {
-    ConfigParseException::ConfigParseException(const char* what) noexcept {
-        this->reason = std::string(what);
-    }
+    ConfigParseException::ConfigParseException(const char* what) noexcept { this->reason = std::string(what); }
 
-    const char* ConfigParseException::what() const noexcept {
-        return this->reason.c_str();
-    }
-}
+    const char* ConfigParseException::what() const noexcept { return this->reason.c_str(); }
+}  // namespace scinit

--- a/src/ConfigParseException.h
+++ b/src/ConfigParseException.h
@@ -18,17 +18,17 @@
 #define CINIT_CONFIG_PARSE_EXCEPTION_H
 
 #include <exception>
+#include <string>
 
 namespace scinit {
     class ConfigParseException : virtual std::exception {
-    public:
-        explicit ConfigParseException(const char* reason) noexcept;
+      public:
+        explicit ConfigParseException(const char*) noexcept;
         const char* what() const noexcept override;
 
-    private:
+      private:
         std::string reason;
     };
-}
+}  // namespace scinit
 
-
-#endif //CINIT_CONFIG_PARSE_EXCEPTION_H
+#endif  // CINIT_CONFIG_PARSE_EXCEPTION_H

--- a/src/ProcessHandler.cpp
+++ b/src/ProcessHandler.cpp
@@ -37,9 +37,10 @@ namespace scinit {
 
     void ProcessHandler::register_for_process_state(
       int id, std::function<void(ProcessHandlerInterface::ProcessEvent, int)> handler) {
-        if (sig_for_id.count(id) == 0)
+        if (sig_for_id.count(id) == 0) {
             sig_for_id.insert(
-              std::make_pair(id, new boost::signals2::signal<void(ProcessHandlerInterface::ProcessEvent, int)>()));
+              std::make_pair(id, std::make_shared<boost::signals2::signal<void(ProcessHandlerInterface::ProcessEvent, int)>>()));
+        }
         auto signal = sig_for_id[id];
         signal->connect(handler);
     }
@@ -84,17 +85,23 @@ namespace scinit {
 
                 // Strip leading and trailing newlines
                 ssize_t begin = 0;
-                for (; begin < nchars; begin++)
-                    if (buf[begin] != '\n')
+                for (; begin < nchars; begin++) {
+                    if (buf[begin] != '\n') {
                         break;
+                    }
+                }
                 ssize_t end = nchars - 1;
-                for (; end > begin; end--)
-                    if (buf[end] != '\n')
+                for (; end > begin; end--) {
+                    if (buf[end] != '\n') {
                         break;
-                if (begin > 0)
-                    str = str.substr(static_cast<unsigned long>(begin));
-                if (end < nchars - 1 && end >= begin && begin >= 0)
+                    }
+                }
+                if (begin > 0) {
+                    str = str.substr(static_cast<uint64_t>(begin));
+                }
+                if (end < nchars - 1 && end >= begin && begin >= 0) {
                     str = str.substr(0, static_cast<uint64_t>(end - begin + 1));
+                }
 
                 // If there is something left, output it
                 if (!str.empty()) {
@@ -223,8 +230,9 @@ namespace scinit {
     void ProcessHandler::start_programs() {
         for (const auto& weak_program : all_objs) {
             if (auto program = weak_program.lock()) {
-                if (!program->can_start_now())
+                if (!program->can_start_now()) {
                     continue;
+                }
                 try {
                     // Register logger
                     auto console = spdlog::stdout_color_st(program->get_name());

--- a/src/ProcessHandler.cpp
+++ b/src/ProcessHandler.cpp
@@ -38,8 +38,8 @@ namespace scinit {
     void ProcessHandler::register_for_process_state(
       int id, std::function<void(ProcessHandlerInterface::ProcessEvent, int)> handler) {
         if (sig_for_id.count(id) == 0) {
-            sig_for_id.insert(
-              std::make_pair(id, std::make_shared<boost::signals2::signal<void(ProcessHandlerInterface::ProcessEvent, int)>>()));
+            sig_for_id.insert(std::make_pair(
+              id, std::make_shared<boost::signals2::signal<void(ProcessHandlerInterface::ProcessEvent, int)>>()));
         }
         auto signal = sig_for_id[id];
         signal->connect(handler);

--- a/src/ProcessHandler.h
+++ b/src/ProcessHandler.h
@@ -25,6 +25,7 @@ namespace scinit {
     class ProcessHandler : public ProcessHandlerInterface {
       public:
         ProcessHandler() = default;
+        ~ProcessHandler() override = default;
         ProcessHandler(const ProcessHandler&) = delete;
         virtual ProcessHandler& operator=(const ProcessHandler&) = delete;
 
@@ -35,7 +36,7 @@ namespace scinit {
         int enter_eventloop() override;
 
       private:
-        std::map<int, boost::signals2::signal<void(ProcessHandlerInterface::ProcessEvent, int)>*> sig_for_id;
+        std::map<int, std::shared_ptr<boost::signals2::signal<void(ProcessHandlerInterface::ProcessEvent, int)>>> sig_for_id;
         std::map<unsigned int, std::weak_ptr<ChildProcessInterface>> obj_for_id;
         std::map<int, unsigned int> id_for_pid;
         std::map<int, unsigned int> id_for_fd;

--- a/src/ProcessHandler.h
+++ b/src/ProcessHandler.h
@@ -17,37 +17,36 @@
 #ifndef CINIT_PROCESSHANDLER_H
 #define CINIT_PROCESSHANDLER_H
 
-#include "ProcessHandlerInterface.h"
 #include "gtest/gtest_prod.h"
+#include "ProcessHandlerInterface.h"
 
 namespace scinit {
-
     // See base class for documentation
     class ProcessHandler : public ProcessHandlerInterface {
-    public:
+      public:
         ProcessHandler() = default;
         ProcessHandler(const ProcessHandler&) = delete;
         virtual ProcessHandler& operator=(const ProcessHandler&) = delete;
 
         void register_processes(std::list<std::weak_ptr<ChildProcessInterface>>&) override;
-        void register_for_process_state(int id, std::function<void(ProcessHandlerInterface::ProcessEvent, int)> handler)
-                                            override;
+        void register_for_process_state(
+          int id, std::function<void(ProcessHandlerInterface::ProcessEvent, int)> handler) override;
         void register_obj_id(int, std::weak_ptr<ChildProcessInterface>) override;
         int enter_eventloop() override;
 
-    private:
+      private:
         std::map<int, boost::signals2::signal<void(ProcessHandlerInterface::ProcessEvent, int)>*> sig_for_id;
         std::map<unsigned int, std::weak_ptr<ChildProcessInterface>> obj_for_id;
-        std::map<int, int> id_for_pid;
-        std::map<int, int> id_for_fd;
+        std::map<int, unsigned int> id_for_pid;
+        std::map<int, unsigned int> id_for_fd;
         std::list<std::weak_ptr<ChildProcessInterface>> all_objs;
-        int epoll_fd = -1, signal_fd = -1 , number_of_running_procs = 0;
+        int epoll_fd = -1, signal_fd = -1, number_of_running_procs = 0;
         bool should_quit = false;
 
         void setup_signal_handlers();
         void start_programs();
         void event_received(int fd, unsigned int event);
-        void signal_received(int signal);
+        void signal_received(unsigned int signal);
         void sigchld_received(int pid, int rc);
 
         FRIEND_TEST(ProcessHandlerTests, TestOneRunnableChild);
@@ -55,6 +54,6 @@ namespace scinit {
         FRIEND_TEST(ProcessLifecycleTests, SingleProcessLifecycle);
         FRIEND_TEST(ProcessLifecycleTests, TwoDependantProcessesLifecycle);
     };
-}
+}  // namespace scinit
 
-#endif //CINIT_PROCESSHANDLER_H
+#endif  // CINIT_PROCESSHANDLER_H

--- a/src/ProcessHandler.h
+++ b/src/ProcessHandler.h
@@ -36,7 +36,8 @@ namespace scinit {
         int enter_eventloop() override;
 
       private:
-        std::map<int, std::shared_ptr<boost::signals2::signal<void(ProcessHandlerInterface::ProcessEvent, int)>>> sig_for_id;
+        std::map<int, std::shared_ptr<boost::signals2::signal<void(ProcessHandlerInterface::ProcessEvent, int)>>>
+          sig_for_id;
         std::map<unsigned int, std::weak_ptr<ChildProcessInterface>> obj_for_id;
         std::map<int, unsigned int> id_for_pid;
         std::map<int, unsigned int> id_for_fd;

--- a/src/ProcessHandlerException.cpp
+++ b/src/ProcessHandlerException.cpp
@@ -17,15 +17,9 @@
 #include "ProcessHandlerException.h"
 
 namespace scinit {
-    ProcessHandlerException::ProcessHandlerException(const char* what) noexcept {
-        this->reason = std::string(what);
-    }
+    ProcessHandlerException::ProcessHandlerException(const char* what) noexcept { this->reason = std::string(what); }
 
-    ProcessHandlerException::ProcessHandlerException() noexcept {
-        this->reason = std::string();
-    }
+    ProcessHandlerException::ProcessHandlerException() noexcept { this->reason = std::string(); }
 
-    const char* ProcessHandlerException::what() const noexcept {
-        return this->reason.c_str();
-    }
-}
+    const char* ProcessHandlerException::what() const noexcept { return this->reason.c_str(); }
+}  // namespace scinit

--- a/src/ProcessHandlerException.h
+++ b/src/ProcessHandlerException.h
@@ -22,14 +22,14 @@
 
 namespace scinit {
     class ProcessHandlerException : virtual std::exception {
-    public:
-        explicit ProcessHandlerException(const char* reason) noexcept;
+      public:
+        explicit ProcessHandlerException(const char*) noexcept;
         ProcessHandlerException() noexcept;
         const char* what() const noexcept override;
 
-    private:
+      private:
         std::string reason;
     };
-}
+}  // namespace scinit
 
-#endif //CINIT_PROCESSHANDLEREXCEPTION_H
+#endif  // CINIT_PROCESSHANDLEREXCEPTION_H

--- a/src/ProcessHandlerInterface.h
+++ b/src/ProcessHandlerInterface.h
@@ -17,24 +17,21 @@
 #ifndef CINIT_PROCESSHANDLERINTERFACE_H
 #define CINIT_PROCESSHANDLERINTERFACE_H
 
-#include <memory>
 #include <boost/signals2.hpp>
+#include <memory>
 
 namespace scinit {
     class ChildProcessInterface;
 
     class ProcessHandlerInterface {
-    public:
-        // Somebody defines SIGHUP, so let's remove that for the enum
+      public:
+// Somebody defines SIGHUP, so let's remove that for the enum
 #define TMP_SIGHUP SIGHUP
 #undef SIGHUP
         /*
          * Event notifier reasons: SIGHUP received or process exitted
          */
-        enum ProcessEvent {
-            SIGHUP,
-            EXIT
-        };
+        enum ProcessEvent { SIGHUP, EXIT };
 #define SIGHUP TMP_SIGHUP
         ProcessHandlerInterface() = default;
         // No copy
@@ -62,6 +59,6 @@ namespace scinit {
          */
         virtual int enter_eventloop() = 0;
     };
-}
+}  // namespace scinit
 
-#endif //CINIT_PROCESSHANDLERINTERFACE_H
+#endif  // CINIT_PROCESSHANDLERINTERFACE_H

--- a/src/ProcessHandlerInterface.h
+++ b/src/ProcessHandlerInterface.h
@@ -34,6 +34,7 @@ namespace scinit {
         enum ProcessEvent { SIGHUP, EXIT };
 #define SIGHUP TMP_SIGHUP
         ProcessHandlerInterface() = default;
+        virtual ~ProcessHandlerInterface() = default;
         // No copy
         ProcessHandlerInterface(const ProcessHandlerInterface&) = delete;
         virtual ProcessHandlerInterface& operator=(const ProcessHandlerInterface&) = delete;

--- a/src/log.h
+++ b/src/log.h
@@ -22,4 +22,4 @@
 
 #define LOG spdlog::get("scinit")
 
-#endif //CINIT_LOG_H
+#endif  // CINIT_LOG_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,31 +14,28 @@
  * limitations under the License.
  */
 
-#include <iostream>
-#include <mutex>
-#include <csignal>
 #include <sys/epoll.h>
 #include <sys/signalfd.h>
 #include <sys/wait.h>
-#include "Config.h"
-#include "log.h"
+#include <csignal>
+#include <iostream>
+#include <mutex>
+#include "ChildProcess.h"
 #include "ChildProcessException.h"
 #include "ChildProcessInterface.h"
-#include "ChildProcess.h"
+#include "Config.h"
 #include "ProcessHandler.h"
+#include "log.h"
 
 #define MAX_EVENTS 10
 #define BUF_SIZE 4096
 
-scinit::Config<scinit::ChildProcessInterface>* handle_commandline_invocation(int argc, char** argv,
-                                                             std::shared_ptr<scinit::ProcessHandlerInterface> handler)
-noexcept(false) {
+scinit::Config<scinit::ChildProcessInterface>* handle_commandline_invocation(
+  int argc, char** argv, const std::shared_ptr<scinit::ProcessHandlerInterface>& handler) noexcept(false) {
     po::options_description desc("Options");
-    desc.add_options()
-            ("help", "print this message")
-            ("config", po::value<std::string>()->default_value("config.yml"), "path to config file")
-            ("verbose", po::value<bool>()->default_value(false), "be verbose")
-            ;
+    desc.add_options()("help", "print this message")("config", po::value<std::string>()->default_value("config.yml"),
+                                                     "path to config file")(
+      "verbose", po::value<bool>()->default_value(false), "be verbose");
     po::variables_map options;
     po::store(po::parse_command_line(argc, argv, desc), options);
     po::notify(options);
@@ -69,9 +66,8 @@ noexcept(false) {
                 files.push_back(file.path().native());
         }
         return new scinit::Config<scinit::ChildProcessInterface>(files, handler);
-    } else {
-        return new scinit::Config<scinit::ChildProcessInterface>(config, handler);
     }
+    return new scinit::Config<scinit::ChildProcessInterface>(config, handler);
 }
 
 int main(int argc, char** argv) {
@@ -81,7 +77,7 @@ int main(int argc, char** argv) {
     if (conf == nullptr)
         return -1;
     auto child_list = conf->get_processes();
-    handler -> register_processes(child_list);
+    handler->register_processes(child_list);
 
     return handler->enter_eventloop();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,10 +47,11 @@ scinit::Config<scinit::ChildProcessInterface>* handle_commandline_invocation(
 
     auto console = spdlog::stdout_color_st("scinit");
     console->set_pattern("[%^%n%$] [%H:%M:%S.%e] [%l] %v");
-    if (options["verbose"].as<bool>())
+    if (options["verbose"].as<bool>()) {
         console->set_level(spdlog::level::debug);
-    else
+    } else {
         console->set_level(spdlog::level::info);
+    }
 
     auto config = options["config"].as<std::string>();
     // Check whether 'config' is a file or a directory
@@ -62,8 +63,9 @@ scinit::Config<scinit::ChildProcessInterface>* handle_commandline_invocation(
     if (fs::is_directory(config_path)) {
         std::list<std::string> files;
         for (auto& file : fs::directory_iterator(config_path)) {
-            if (fs::is_regular(file))
+            if (fs::is_regular(file)) {
                 files.push_back(file.path().native());
+            }
         }
         return new scinit::Config<scinit::ChildProcessInterface>(files, handler);
     }
@@ -74,8 +76,9 @@ int main(int argc, char** argv) {
     auto handler = std::make_shared<scinit::ProcessHandler>();
 
     auto conf = handle_commandline_invocation(argc, argv, handler);
-    if (conf == nullptr)
+    if (conf == nullptr) {
         return -1;
+    }
     auto child_list = conf->get_processes();
     handler->register_processes(child_list);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,4 +32,6 @@ add_executable(process_lifecycle_tests ${ABS_SCINIT_SOURCE_FILES} test_process_l
 target_link_libraries(process_lifecycle_tests yaml-cpp pthread cap gmock_main ${Boost_LIBRARIES})
 
 # Make unit tests available to 'make test'
-gtest_add_tests(TARGET config_tests SOURCES test_config_parser.cpp test_process_handler.cpp test_process_lifecycle.cpp)
+gtest_add_tests(TARGET config_tests SOURCES test_config_parser.cpp)
+gtest_add_tests(TARGET process_handler_tests SOURCES test_process_handler.cpp)
+gtest_add_tests(TARGET process_lifecycle_tests SOURCES test_process_lifecycle.cpp)

--- a/test/MockEventHandlers.h
+++ b/test/MockEventHandlers.h
@@ -20,11 +20,11 @@
 #include "../3rdparty/googletest/googlemock/include/gmock/gmock.h"
 namespace scinit {
     class MockEventHandlers {
-    public:
+      public:
         MockEventHandlers() = default;
 
         MOCK_METHOD0(call_once, void());
     };
 }  // namespace scinit
 
-#endif //CINIT_MOCKEVENTHANDLERS_H
+#endif  // CINIT_MOCKEVENTHANDLERS_H

--- a/test/process_handler_test/MockChildProcess.h
+++ b/test/process_handler_test/MockChildProcess.h
@@ -25,21 +25,21 @@ namespace scinit {
     namespace test {
         namespace handler {
             class MockChildProcess : public ChildProcessInterface {
-            public:
+              public:
                 MOCK_CONST_METHOD0(get_name, std::string());
                 MOCK_CONST_METHOD0(get_id, unsigned int());
                 MOCK_CONST_METHOD0(can_start_now, bool());
                 MOCK_METHOD1(notify_of_state, void(std::map<unsigned int, std::weak_ptr<ChildProcessInterface>>));
                 MOCK_METHOD1(propagate_dependencies, void(std::list<std::weak_ptr<ChildProcessInterface>>));
                 MOCK_METHOD2(handle_process_event, void(ProcessHandlerInterface::ProcessEvent, int));
-                MOCK_METHOD2(should_wait_for, void(int, ProcessState));
+                MOCK_METHOD2(should_wait_for, void(unsigned int, ProcessState));
                 MOCK_CONST_METHOD0(get_state, ProcessState());
 
-                MOCK_METHOD1(do_fork, void(std::map<int, int> &));
-                MOCK_METHOD2(register_with_epoll, void(int, std::map<int, int> & ));
+                MOCK_METHOD1(do_fork, void(std::map<int, unsigned int> &));
+                MOCK_METHOD2(register_with_epoll, void(int, std::map<int, unsigned int> &));
             };
         }
     }
 }  // namespace scinit
 
-#endif //CINIT_MOCKCHILDPROCESS_HANDLER_H
+#endif  // CINIT_MOCKCHILDPROCESS_HANDLER_H

--- a/test/process_lifecycle_test/MockChildProcess.h
+++ b/test/process_lifecycle_test/MockChildProcess.h
@@ -25,16 +25,17 @@ namespace scinit {
         namespace lifecycle {
             class MockChildProcess : public ChildProcess {
               public:
-                MockChildProcess(std::string name, std::string path, std::list<std::string> args, const std::string& type,
-                                 std::list<std::string> capabilities, unsigned int uid, unsigned int gid,
-                                 unsigned int graph_id, const std::shared_ptr<ProcessHandlerInterface>& handler,
-                                 std::list<std::string> before, std::list<std::string> after)
+                MockChildProcess(std::string name, std::string path, std::list<std::string> args,
+                                 const std::string& type, std::list<std::string> capabilities, unsigned int uid,
+                                 unsigned int gid, unsigned int graph_id,
+                                 const std::shared_ptr<ProcessHandlerInterface>& handler, std::list<std::string> before,
+                                 std::list<std::string> after)
                   : ChildProcess(std::move(name), std::move(path), std::move(args), std::move(type),
                                  std::move(capabilities), uid, gid, graph_id, std::move(handler), std::move(before),
                                  std::move(after)){};
 
-                MOCK_METHOD1(do_fork, void(std::map<int, unsigned int> &));
-                MOCK_METHOD2(register_with_epoll, void(int epoll_fd, std::map<int, unsigned int> &map));
+                MOCK_METHOD1(do_fork, void(std::map<int, unsigned int>&));
+                MOCK_METHOD2(register_with_epoll, void(int epoll_fd, std::map<int, unsigned int>& map));
             };
         }
     }

--- a/test/process_lifecycle_test/MockChildProcess.h
+++ b/test/process_lifecycle_test/MockChildProcess.h
@@ -24,20 +24,20 @@ namespace scinit {
     namespace test {
         namespace lifecycle {
             class MockChildProcess : public ChildProcess {
-            public:
-                MockChildProcess(const std::string &name, const std::string &path, const std::list<std::string> &args,
-                                 const std::string &type, const std::list<std::string> &capabilities, unsigned int uid,
-                                 unsigned int gid, unsigned int graph_id,
-                                 std::shared_ptr<ProcessHandlerInterface> handler, const std::list<std::string> &before,
-                                 const std::list<std::string> &after) :
-                        ChildProcess(name, path, args, type, capabilities, uid, gid, graph_id, handler, before, after) {
-                };
+              public:
+                MockChildProcess(std::string name, std::string path, std::list<std::string> args, std::string type,
+                                 std::list<std::string> capabilities, unsigned int uid, unsigned int gid,
+                                 unsigned int graph_id, std::shared_ptr<ProcessHandlerInterface> handler,
+                                 std::list<std::string> before, std::list<std::string> after)
+                  : ChildProcess(std::move(name), std::move(path), std::move(args), std::move(type),
+                                 std::move(capabilities), uid, gid, graph_id, std::move(handler), std::move(before),
+                                 std::move(after)){};
 
-                MOCK_METHOD1(do_fork, void(std::map<int, int>&));
-                MOCK_METHOD2(register_with_epoll, void(int epoll_fd, std::map<int, int>& map));
+                MOCK_METHOD1(do_fork, void(std::map<int, int> &));
+                MOCK_METHOD2(register_with_epoll, void(int epoll_fd, std::map<int, int> &map));
             };
         }
     }
 }  // namespace scinit
 
-#endif //CINIT_MOCKCHILDPROCESS_LIFECYCLE_H
+#endif  // CINIT_MOCKCHILDPROCESS_LIFECYCLE_H

--- a/test/process_lifecycle_test/MockChildProcess.h
+++ b/test/process_lifecycle_test/MockChildProcess.h
@@ -33,8 +33,8 @@ namespace scinit {
                                  std::move(capabilities), uid, gid, graph_id, std::move(handler), std::move(before),
                                  std::move(after)){};
 
-                MOCK_METHOD1(do_fork, void(std::map<int, int> &));
-                MOCK_METHOD2(register_with_epoll, void(int epoll_fd, std::map<int, int> &map));
+                MOCK_METHOD1(do_fork, void(std::map<int, unsigned int> &));
+                MOCK_METHOD2(register_with_epoll, void(int epoll_fd, std::map<int, unsigned int> &map));
             };
         }
     }

--- a/test/process_lifecycle_test/MockChildProcess.h
+++ b/test/process_lifecycle_test/MockChildProcess.h
@@ -25,9 +25,9 @@ namespace scinit {
         namespace lifecycle {
             class MockChildProcess : public ChildProcess {
               public:
-                MockChildProcess(std::string name, std::string path, std::list<std::string> args, std::string type,
+                MockChildProcess(std::string name, std::string path, std::list<std::string> args, const std::string& type,
                                  std::list<std::string> capabilities, unsigned int uid, unsigned int gid,
-                                 unsigned int graph_id, std::shared_ptr<ProcessHandlerInterface> handler,
+                                 unsigned int graph_id, const std::shared_ptr<ProcessHandlerInterface>& handler,
                                  std::list<std::string> before, std::list<std::string> after)
                   : ChildProcess(std::move(name), std::move(path), std::move(args), std::move(type),
                                  std::move(capabilities), uid, gid, graph_id, std::move(handler), std::move(before),

--- a/test/test_config_parser.cpp
+++ b/test/test_config_parser.cpp
@@ -29,7 +29,7 @@ namespace scinit {
       protected:
         fs::path test_resource;
 
-        void SetUp() {
+        void SetUp() override {
             test_resource = fs::path(__FILE__);
             ASSERT_TRUE(fs::is_regular_file(test_resource)) << "Path to source does not point to a regular file";
             test_resource.remove_filename();
@@ -81,8 +81,9 @@ namespace scinit {
         ASSERT_TRUE(fs::is_directory(test_resource)) << "Test resource missing";
         std::list<std::string> files;
         for (auto &file : fs::directory_iterator(test_resource)) {
-            if (fs::is_regular(file))
+            if (fs::is_regular(file)) {
                 files.push_back(file.path().native());
+            }
         }
         auto handler = std::make_shared<scinit::ProcessHandler>();
         scinit::Config<ChildProcess> uut(files, handler);

--- a/test/test_config_parser.cpp
+++ b/test/test_config_parser.cpp
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-#include <boost/filesystem.hpp>
-#include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <boost/filesystem.hpp>
 #include "../src/ChildProcess.h"
 #include "../src/Config.h"
-#include "../src/log.h"
 #include "../src/ProcessHandler.h"
+#include "../src/log.h"
 
 namespace fs = boost::filesystem;
 
 namespace scinit {
     class ConfigParserTests : public testing::Test {
-    protected:
+      protected:
         fs::path test_resource;
 
         void SetUp() {
@@ -80,7 +80,7 @@ namespace scinit {
         test_resource /= "conf.d";
         ASSERT_TRUE(fs::is_directory(test_resource)) << "Test resource missing";
         std::list<std::string> files;
-        for (auto& file : fs::directory_iterator(test_resource)) {
+        for (auto &file : fs::directory_iterator(test_resource)) {
             if (fs::is_regular(file))
                 files.push_back(file.path().native());
         }
@@ -161,10 +161,8 @@ namespace scinit {
         try {
             scinit::Config<ChildProcess> uut(test_resource.native(), handler);
             FAIL() << "Expected an exception when parsing invalid YAML...";
-        } catch (std::exception& e) {
+        } catch (std::exception &e) {
             ASSERT_THAT(e.what(), ::testing::StartsWith("yaml-cpp: error at line 5, column 14: illegal EOF in scalar"));
-        } catch (...) {
-            FAIL() << "Wrong exception type";
-        }
+        } catch (...) { FAIL() << "Wrong exception type"; }
     }
-}
+}  // namespace scinit

--- a/test/test_process_handler.cpp
+++ b/test/test_process_handler.cpp
@@ -27,7 +27,7 @@ using namespace scinit::test::handler;
 namespace scinit {
     class ProcessHandlerTests : public testing::Test {
       protected:
-        void SetUp() {
+        void SetUp() override {
             if (!spdlog::get("scinit")) {
                 auto console = spdlog::stdout_color_st("scinit");
                 console->set_pattern("[%^%n%$] [%H:%M:%S.%e] [%l] %v");
@@ -35,7 +35,7 @@ namespace scinit {
             }
         }
 
-        void TearDown() { spdlog::drop_all(); }
+        void TearDown() override { spdlog::drop_all(); }
     };
 
     TEST_F(ProcessHandlerTests, TestOneRunnableChild) {

--- a/test/test_process_handler.cpp
+++ b/test/test_process_handler.cpp
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#include "gtest/gtest.h"
 #include "gmock/gmock.h"
-#include "process_handler_test/MockChildProcess.h"
-#include "MockEventHandlers.h"
+#include "gtest/gtest.h"
 #include "../src/log.h"
+#include "MockEventHandlers.h"
+#include "process_handler_test/MockChildProcess.h"
 
 using ::testing::Return;
 using ::testing::_;
@@ -26,7 +26,7 @@ using namespace scinit::test::handler;
 
 namespace scinit {
     class ProcessHandlerTests : public testing::Test {
-    protected:
+      protected:
         void SetUp() {
             if (!spdlog::get("scinit")) {
                 auto console = spdlog::stdout_color_st("scinit");
@@ -35,16 +35,14 @@ namespace scinit {
             }
         }
 
-        void TearDown() {
-            spdlog::drop_all();
-        }
+        void TearDown() { spdlog::drop_all(); }
     };
 
     TEST_F(ProcessHandlerTests, TestOneRunnableChild) {
         auto child_1 = std::make_shared<MockChildProcess>();
         EXPECT_CALL(*child_1, can_start_now()).WillRepeatedly(Return(true));
         EXPECT_CALL(*child_1, do_fork(_)).Times(1);
-        EXPECT_CALL(*child_1, register_with_epoll(_,_)).Times(1);
+        EXPECT_CALL(*child_1, register_with_epoll(_, _)).Times(1);
         EXPECT_CALL(*child_1, get_name()).Times(2).WillRepeatedly(Return("mockprog"));
         std::list<std::weak_ptr<ChildProcessInterface>> all_children;
         all_children.push_back(child_1);
@@ -60,7 +58,7 @@ namespace scinit {
         auto child_1 = std::make_shared<MockChildProcess>();
         EXPECT_CALL(*child_1, can_start_now()).WillRepeatedly(Return(true));
         EXPECT_CALL(*child_1, do_fork(_)).Times(1);
-        EXPECT_CALL(*child_1, register_with_epoll(_,_)).Times(1);
+        EXPECT_CALL(*child_1, register_with_epoll(_, _)).Times(1);
         EXPECT_CALL(*child_1, get_name()).Times(3).WillRepeatedly(Return("mockprog"));
         std::list<std::weak_ptr<ChildProcessInterface>> all_children;
         all_children.push_back(child_1);
@@ -85,4 +83,4 @@ namespace scinit {
         EXPECT_EQ(handler.number_of_running_procs, 0);
         delete mock_events;
     }
-}
+}  // namespace scinit

--- a/test/test_process_lifecycle.cpp
+++ b/test/test_process_lifecycle.cpp
@@ -16,8 +16,8 @@
 
 #include "../src/ProcessHandler.h"
 #include "../src/log.h"
-#include "process_lifecycle_test/MockChildProcess.h"
 #include "MockEventHandlers.h"
+#include "process_lifecycle_test/MockChildProcess.h"
 
 using ::testing::Invoke;
 using ::testing::_;
@@ -25,7 +25,7 @@ using namespace scinit::test::lifecycle;
 
 namespace scinit {
     class ProcessLifecycleTests : public testing::Test {
-    protected:
+      protected:
         std::list<std::function<void(void)>> cleanup_functions;
         void SetUp() {
             if (!spdlog::get("scinit")) {
@@ -37,37 +37,39 @@ namespace scinit {
 
         void TearDown() {
             spdlog::drop_all();
-            for (auto fun: cleanup_functions)
+            for (auto fun : cleanup_functions)
                 fun();
         }
 
         void expect_normal_run_for_child(std::shared_ptr<MockChildProcess> child,
                                          const std::shared_ptr<ProcessHandler>& handler, int pid) {
-            MockEventHandlers *signal_event = new MockEventHandlers(),
-                    *fork_event = new MockEventHandlers(),
-                    *register_event = new MockEventHandlers();
+            MockEventHandlers *signal_event = new MockEventHandlers(), *fork_event = new MockEventHandlers(),
+                              *register_event = new MockEventHandlers();
             // Child 1 mock
             EXPECT_CALL(*fork_event, call_once()).Times(1);
-            EXPECT_CALL(*child, do_fork(_)).Times(1).WillOnce(Invoke([fork_event, &child, pid]
-                                                                             (std::map<int, int>& reg) {
-                fork_event->call_once();
-                EXPECT_EQ(child->state, ChildProcessInterface::ProcessState::READY);
-                child->state = ChildProcessInterface::ProcessState::RUNNING;
-                child->primaryPid = 0;
-                reg[pid] = child->get_id();
-            }));
+            EXPECT_CALL(*child, do_fork(_))
+              .Times(1)
+              .WillOnce(Invoke([fork_event, &child, pid](std::map<int, int>& reg) {
+                  fork_event->call_once();
+                  EXPECT_EQ(child->state, ChildProcessInterface::ProcessState::READY);
+                  child->state = ChildProcessInterface::ProcessState::RUNNING;
+                  child->primaryPid = 0;
+                  reg[pid] = child->get_id();
+              }));
             EXPECT_CALL(*register_event, call_once()).Times(1);
-            EXPECT_CALL(*child, register_with_epoll(_, _)).Times(1).WillOnce(Invoke([register_event](int epoll_fd,
-                                                                                           std::map<int, int>& map) {
-                register_event->call_once();
-                map[0] = 0;
-            }));
+            EXPECT_CALL(*child, register_with_epoll(_, _))
+              .Times(1)
+              .WillOnce(Invoke([register_event](int, std::map<int, int>& map) {
+                  register_event->call_once();
+                  map[0] = 0;
+              }));
             EXPECT_CALL(*signal_event, call_once()).Times(1);
-            handler->register_for_process_state(0, [signal_event](ProcessHandlerInterface::ProcessEvent event, int result) {
-                signal_event->call_once();
-                EXPECT_EQ(event, ProcessHandlerInterface::ProcessEvent::EXIT);
-                EXPECT_EQ(result, 0);
-            });
+            handler->register_for_process_state(
+              0, [signal_event](ProcessHandlerInterface::ProcessEvent event, int result) {
+                  signal_event->call_once();
+                  EXPECT_EQ(event, ProcessHandlerInterface::ProcessEvent::EXIT);
+                  EXPECT_EQ(result, 0);
+              });
             cleanup_functions.emplace_back([signal_event, fork_event, register_event]() {
                 delete signal_event;
                 delete fork_event;
@@ -80,8 +82,8 @@ namespace scinit {
         auto handler = std::make_shared<ProcessHandler>();
 
         std::list<std::string> args, capabilities, before, after;
-        auto child_1 = std::make_shared<MockChildProcess>("mockproc", "/bin/false", args, "SIMPLE", capabilities,
-                65534, 65534, 0, handler, before, after);
+        auto child_1 = std::make_shared<MockChildProcess>("mockproc", "/bin/false", args, "SIMPLE", capabilities, 65534,
+                                                          65534, 0, handler, before, after);
         handler->obj_for_id[0] = child_1;
         std::list<std::weak_ptr<ChildProcessInterface>> all_children;
         all_children.push_back(child_1);
@@ -144,4 +146,4 @@ namespace scinit {
         EXPECT_EQ(child_2->state, ChildProcessInterface::ProcessState::DONE);
         EXPECT_EQ(handler->number_of_running_procs, 0);
     }
-}
+}  // namespace scinit

--- a/test/test_process_lifecycle.cpp
+++ b/test/test_process_lifecycle.cpp
@@ -27,7 +27,7 @@ namespace scinit {
     class ProcessLifecycleTests : public testing::Test {
       protected:
         std::list<std::function<void(void)>> cleanup_functions;
-        void SetUp() {
+        void SetUp() override {
             if (!spdlog::get("scinit")) {
                 auto console = spdlog::stdout_color_st("scinit");
                 console->set_pattern("[%^%n%$] [%H:%M:%S.%e] [%l] %v");
@@ -35,7 +35,7 @@ namespace scinit {
             }
         }
 
-        void TearDown() {
+        void TearDown() override {
             spdlog::drop_all();
             for (auto fun : cleanup_functions)
                 fun();

--- a/test/test_programs/zombie.cpp
+++ b/test/test_programs/zombie.cpp
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#include <iostream>
 #include <unistd.h>
+#include <iostream>
 
 // Fork a child and do not check it's status.
-int main (int argc, char** argv) {
+int main(int, char**) {
     int pid = fork();
     if (pid == 0) {
         return -1;


### PR DESCRIPTION
Clang-format should make for consistent formatting while clang-tidy is
supposed to catch common mistakes. If this build fails CI, then it means
that they get executed automatically.