### PR TITLE
Core: Introduce user/group options

### DIFF
--- a/src/ChildProcess.h
+++ b/src/ChildProcess.h
@@ -64,6 +64,7 @@ namespace scinit {
         FRIEND_TEST(ConfigParserTests, SmokeTestConfig);
         FRIEND_TEST(ConfigParserTests, SimpleConfDTest);
         FRIEND_TEST(ConfigParserTests, ConfigWithDeps);
+        FRIEND_TEST(ConfigParserTests, ConfigWithNamedUser);
         FRIEND_TEST(ProcessLifecycleTests, SingleProcessLifecycle);
         FRIEND_TEST(ProcessLifecycleTests, TwoDependantProcessesLifecycle);
         friend class ProcessLifecycleTests;

--- a/test/test_configs/config-with-named-user.yml
+++ b/test/test_configs/config-with-named-user.yml
@@ -1,0 +1,11 @@
+programs:
+  - name: ping
+    path: ./ping
+    args:
+      - -c 4
+      - google.ch
+    user: nobody
+    group: nogroup
+    type: oneshot
+    capabilities:
+      - CAP_NET_RAW


### PR DESCRIPTION
Add user and group options which allow specifying uid/gid by name. If
uid/gid have already been specified, it will result in a warning.