### PR TITLE
Core: Put stdout and stderr onto different pipes.

### DIFF
--- a/src/ChildProcess.h
+++ b/src/ChildProcess.h
@@ -36,10 +36,11 @@ namespace scinit {
 
         ChildProcess(const ChildProcess &) = delete;
         virtual ChildProcess &operator=(const ChildProcess &) = delete;
-        virtual ~ChildProcess() = default;
+        ~ChildProcess() override = default;
 
         void do_fork(std::map<int, unsigned int> &) noexcept(false) override;
-        void register_with_epoll(int, std::map<int, unsigned int> &) noexcept(false) override;
+        void register_with_epoll(int, std::map<int, unsigned int> &,
+                                 std::map<int, ProcessHandlerInterface::FDType> &) noexcept(false) override;
         std::string get_name() const noexcept override;
         unsigned int get_id() const noexcept override;
         bool can_start_now() const noexcept override;
@@ -49,17 +50,17 @@ namespace scinit {
         void handle_process_event(ProcessHandlerInterface::ProcessEvent event, int data) noexcept override;
         ProcessState get_state() const noexcept override;
 
-      private:
+      protected:
         std::string name, path;
         std::list<std::string> args, capabilities;
         unsigned int uid, gid, graph_id;
         std::shared_ptr<ProcessHandlerInterface> handler;
         std::list<std::string> before, after;
         std::list<std::pair<unsigned int, ChildProcessInterface::ProcessState>> conditions;
-        int stdouterr[2] = {-1, -1}, primaryPid = -1;
+        int stdout[2] = {-1, -1}, stderr[2] = {-1, -1}, primaryPid = -1;
         ProcessType type;
         ProcessState state;
-        void handle_caps();
+        virtual void handle_caps();
 
         FRIEND_TEST(ConfigParserTests, SmokeTestConfig);
         FRIEND_TEST(ConfigParserTests, SimpleConfDTest);
@@ -67,6 +68,7 @@ namespace scinit {
         FRIEND_TEST(ConfigParserTests, ConfigWithNamedUser);
         FRIEND_TEST(ProcessLifecycleTests, SingleProcessLifecycle);
         FRIEND_TEST(ProcessLifecycleTests, TwoDependantProcessesLifecycle);
+        FRIEND_TEST(IntegrationTests, TestStdOutErr);
         friend class ProcessLifecycleTests;
     };
 }  // namespace scinit

--- a/src/ChildProcessInterface.h
+++ b/src/ChildProcessInterface.h
@@ -60,7 +60,8 @@ namespace scinit {
          * In order to handle stdout/stderr forwarding, the pipe needs to be registered with epoll,
          * which is what this function does. It also registers the fd to the current object.
          */
-        virtual void register_with_epoll(int epollfd, std::map<int, unsigned int>& fd_to_obj) = 0;
+        virtual void register_with_epoll(int epollfd, std::map<int, unsigned int>& fd_to_obj,
+                                         std::map<int, ProcessHandlerInterface::FDType>& fd_type) = 0;
 
         /*
          * This function is called by the process handler with a list of all existing processes as an argument.

--- a/src/Config.h
+++ b/src/Config.h
@@ -40,7 +40,7 @@ namespace scinit {
 
     // See base class for documentation
     template <class CTYPE>
-    class Config : public ConfigInterface<CTYPE> {
+    class Config : public ConfigInterface {
       public:
         Config(const std::string& path, std::shared_ptr<ProcessHandlerInterface> handler) noexcept(false)
           : handler(handler) {
@@ -61,9 +61,9 @@ namespace scinit {
 
         ~Config() override = default;
 
-        std::list<std::weak_ptr<CTYPE>> get_processes() const noexcept override {
-            return std::accumulate(processes.begin(), processes.end(), std::list<std::weak_ptr<CTYPE>>(),
-                                   [](auto list, auto ptr) {
+        std::list<std::weak_ptr<ChildProcessInterface>> get_processes() const noexcept override {
+            return std::accumulate(processes.begin(), processes.end(),
+                                   std::list<std::weak_ptr<ChildProcessInterface>>(), [](auto list, auto ptr) {
                                        list.push_back(ptr);
                                        return list;
                                    });
@@ -155,9 +155,9 @@ namespace scinit {
                     }
                 }
 
-                auto process = std::make_shared<ChildProcess>(
-                  (*program)["name"].as<std::string>(), (*program)["path"].as<std::string>(), arg_list, type,
-                  capabilities, uid, gid, child_counter++, handler, before, after);
+                auto process = std::make_shared<CTYPE>((*program)["name"].as<std::string>(),
+                                                       (*program)["path"].as<std::string>(), arg_list, type,
+                                                       capabilities, uid, gid, child_counter++, handler, before, after);
                 processes.push_back(process);
                 handler->register_obj_id(process->get_id(), process);
             }

--- a/src/ConfigInterface.h
+++ b/src/ConfigInterface.h
@@ -23,7 +23,6 @@
 namespace scinit {
     class ChildProcessInterface;
 
-    template <class CTYPE>
     class ConfigInterface {
       public:
         ConfigInterface() = default;
@@ -34,7 +33,7 @@ namespace scinit {
         virtual ConfigInterface& operator=(const ConfigInterface&) = delete;
 
         // Get a list of _all_ processes
-        virtual std::list<std::weak_ptr<CTYPE>> get_processes() const noexcept = 0;
+        virtual std::list<std::weak_ptr<ChildProcessInterface>> get_processes() const noexcept = 0;
     };
 }  // namespace scinit
 

--- a/src/ProcessHandler.h
+++ b/src/ProcessHandler.h
@@ -36,15 +36,6 @@ namespace scinit {
         int enter_eventloop() override;
 
       private:
-        std::map<int, std::shared_ptr<boost::signals2::signal<void(ProcessHandlerInterface::ProcessEvent, int)>>>
-          sig_for_id;
-        std::map<unsigned int, std::weak_ptr<ChildProcessInterface>> obj_for_id;
-        std::map<int, unsigned int> id_for_pid;
-        std::map<int, unsigned int> id_for_fd;
-        std::list<std::weak_ptr<ChildProcessInterface>> all_objs;
-        int epoll_fd = -1, signal_fd = -1, number_of_running_procs = 0;
-        bool should_quit = false;
-
         void setup_signal_handlers();
         void start_programs();
         void event_received(int fd, unsigned int event);
@@ -55,6 +46,19 @@ namespace scinit {
         FRIEND_TEST(ProcessHandlerTests, TestOneChildLifecycle);
         FRIEND_TEST(ProcessLifecycleTests, SingleProcessLifecycle);
         FRIEND_TEST(ProcessLifecycleTests, TwoDependantProcessesLifecycle);
+        FRIEND_TEST(IntegrationTests, TestStdOutErr);
+
+      protected:
+        virtual void handle_child_output(int, const std::string&);
+        std::map<int, std::shared_ptr<boost::signals2::signal<void(ProcessHandlerInterface::ProcessEvent, int)>>>
+          sig_for_id;
+        std::map<unsigned int, std::weak_ptr<ChildProcessInterface>> obj_for_id;
+        std::map<int, unsigned int> id_for_pid;
+        std::map<int, unsigned int> id_for_fd;
+        std::map<int, ProcessHandlerInterface::FDType> fd_type;
+        std::list<std::weak_ptr<ChildProcessInterface>> all_objs;
+        int epoll_fd = -1, signal_fd = -1, number_of_running_procs = 0;
+        bool should_quit = false;
     };
 }  // namespace scinit
 

--- a/src/ProcessHandlerInterface.h
+++ b/src/ProcessHandlerInterface.h
@@ -59,6 +59,11 @@ namespace scinit {
          * Called by main. This function should not exit until the program is supposed to exit
          */
         virtual int enter_eventloop() = 0;
+
+        /*
+         * Type of file descriptors that are registered by child processes
+         */
+        enum FDType { STDOUT, STDERR };
     };
 }  // namespace scinit
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,6 @@
 #include <mutex>
 #include "ChildProcess.h"
 #include "ChildProcessException.h"
-#include "ChildProcessInterface.h"
 #include "Config.h"
 #include "ProcessHandler.h"
 #include "log.h"
@@ -30,7 +29,7 @@
 #define MAX_EVENTS 10
 #define BUF_SIZE 4096
 
-std::unique_ptr<scinit::Config<scinit::ChildProcessInterface>> handle_commandline_invocation(
+std::unique_ptr<scinit::Config<scinit::ChildProcess>> handle_commandline_invocation(
   int argc, char** argv, const std::shared_ptr<scinit::ProcessHandlerInterface>& handler) noexcept(false) {
     po::options_description desc("Options");
     desc.add_options()("help", "print this message")("config", po::value<std::string>()->default_value("config.yml"),
@@ -67,9 +66,9 @@ std::unique_ptr<scinit::Config<scinit::ChildProcessInterface>> handle_commandlin
                 files.push_back(file.path().native());
             }
         }
-        return std::make_unique<scinit::Config<scinit::ChildProcessInterface>>(files, handler);
+        return std::make_unique<scinit::Config<scinit::ChildProcess>>(files, handler);
     }
-    return std::make_unique<scinit::Config<scinit::ChildProcessInterface>>(config, handler);
+    return std::make_unique<scinit::Config<scinit::ChildProcess>>(config, handler);
 }
 
 int main(int argc, char** argv) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 # Test binaries
 add_executable(zombie test_programs/zombie.cpp)
+add_executable(stdouterr test_programs/stdouterr.cpp)
 
 # Config unit tests
 
@@ -30,8 +31,12 @@ target_link_libraries(process_handler_tests yaml-cpp pthread cap gmock_main ${Bo
 add_executable(process_lifecycle_tests ${ABS_SCINIT_SOURCE_FILES} test_process_lifecycle.cpp
         process_lifecycle_test/MockChildProcess.h)
 target_link_libraries(process_lifecycle_tests yaml-cpp pthread cap gmock_main ${Boost_LIBRARIES})
+# Full integration test
+add_executable(integration_tests ${ABS_SCINIT_SOURCE_FILES} test_integration.cpp integration_test/MockChildProcess.h integration_test/MockProcessHandler.h)
+target_link_libraries(integration_tests yaml-cpp pthread cap gmock_main ${Boost_LIBRARIES})
 
 # Make unit tests available to 'make test'
 gtest_add_tests(TARGET config_tests SOURCES test_config_parser.cpp)
 gtest_add_tests(TARGET process_handler_tests SOURCES test_process_handler.cpp)
 gtest_add_tests(TARGET process_lifecycle_tests SOURCES test_process_lifecycle.cpp)
+gtest_add_tests(TARGET integration_tests SOURCES test_integration.cpp)

--- a/test/integration_test/MockChildProcess.h
+++ b/test/integration_test/MockChildProcess.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef CINIT_MOCKCHILDPROCESS_LIFECYCLE_H
-#define CINIT_MOCKCHILDPROCESS_LIFECYCLE_H
+#ifndef CINIT_MOCKCHILDPROCESS_INTEGRATION_H
+#define CINIT_MOCKCHILDPROCESS_INTEGRATION_H
 
 #include "gmock/gmock.h"
 #include "../../src/ChildProcess.h"
@@ -41,4 +41,4 @@ namespace scinit {
     }
 }  // namespace scinit
 
-#endif  // CINIT_MOCKCHILDPROCESS_LIFECYCLE_H
+#endif  // CINIT_MOCKCHILDPROCESS_INTEGRATION_H

--- a/test/integration_test/MockChildProcess.h
+++ b/test/integration_test/MockChildProcess.h
@@ -22,7 +22,7 @@
 
 namespace scinit {
     namespace test {
-        namespace lifecycle {
+        namespace integration {
             class MockChildProcess : public ChildProcess {
               public:
                 MockChildProcess(std::string name, std::string path, std::list<std::string> args,
@@ -34,9 +34,8 @@ namespace scinit {
                                  std::move(capabilities), uid, gid, graph_id, std::move(handler), std::move(before),
                                  std::move(after)){};
 
-                MOCK_METHOD1(do_fork, void(std::map<int, unsigned int>&));
-                MOCK_METHOD3(register_with_epoll, void(int epoll_fd, std::map<int, unsigned int>& map,
-                                                       std::map<int, ProcessHandlerInterface::FDType>&));
+              protected:
+                void handle_caps() override{};
             };
         }
     }

--- a/test/integration_test/MockProcessHandler.h
+++ b/test/integration_test/MockProcessHandler.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 The scinit authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CINIT_MOCKPROCESSHANDLER_LIFECYCLE_H
+#define CINIT_MOCKPROCESSHANDLER_LIFECYCLE_H
+
+#include "gmock/gmock.h"
+#include "../../src/ProcessHandler.h"
+
+namespace scinit {
+    namespace test {
+        namespace integration {
+            class MockProcessHandler : public ProcessHandler {
+              protected:
+                std::string stdout, stderr;
+
+                void handle_child_output(int fd, const std::string& str) override {
+                    auto id = id_for_fd.at(fd);
+                    if (auto obj = obj_for_id.at(id).lock()) {
+                        std::string name = obj->get_name();
+                        ASSERT_GT(fd_type.count(fd), 0);
+                        switch (fd_type[fd]) {
+                            case FDType::STDOUT:
+                                stdout += str;
+                                break;
+                            case FDType::STDERR:
+                                stderr += str;
+                                break;
+                        }
+                    } else {
+                        FAIL() << "Couldn't load object from list";
+                    }
+                }
+
+              public:
+                const std::string getStdout() const noexcept { return stdout; }
+
+                const std::string getStderr() const noexcept { return stderr; }
+            };
+        }
+    }
+}  // namespace scinit
+
+#endif  // CINIT_MOCKPROCESSHANDLER_LIFECYCLE_H

--- a/test/integration_test/MockProcessHandler.h
+++ b/test/integration_test/MockProcessHandler.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef CINIT_MOCKPROCESSHANDLER_LIFECYCLE_H
-#define CINIT_MOCKPROCESSHANDLER_LIFECYCLE_H
+#ifndef CINIT_MOCKPROCESSHANDLER_INTEGRATION_H
+#define CINIT_MOCKPROCESSHANDLER_INTEGRATION_H
 
 #include "gmock/gmock.h"
 #include "../../src/ProcessHandler.h"
@@ -54,4 +54,4 @@ namespace scinit {
     }
 }  // namespace scinit
 
-#endif  // CINIT_MOCKPROCESSHANDLER_LIFECYCLE_H
+#endif  // CINIT_MOCKPROCESSHANDLER_INTEGRATION_H

--- a/test/process_handler_test/MockChildProcess.h
+++ b/test/process_handler_test/MockChildProcess.h
@@ -36,7 +36,8 @@ namespace scinit {
                 MOCK_CONST_METHOD0(get_state, ProcessState());
 
                 MOCK_METHOD1(do_fork, void(std::map<int, unsigned int> &));
-                MOCK_METHOD2(register_with_epoll, void(int, std::map<int, unsigned int> &));
+                MOCK_METHOD3(register_with_epoll, void(int, std::map<int, unsigned int> &,
+                                                       std::map<int, ProcessHandlerInterface::FDType> &));
             };
         }
     }

--- a/test/test_config_parser.cpp
+++ b/test/test_config_parser.cpp
@@ -52,23 +52,25 @@ namespace scinit {
         auto procs = uut.get_processes();
         ASSERT_EQ(procs.size(), 2);
         for (auto &weak_proc : procs) {
-            if (auto proc = weak_proc.lock()) {
-                if (proc.get()->get_name() == "ping") {
-                    ASSERT_EQ(proc.get()->path, "./ping");
-                    ASSERT_EQ(proc.get()->type, ChildProcess::ProcessType::ONESHOT);
-                    ASSERT_THAT(proc.get()->args, ::testing::ElementsAre("-c 4", "google.ch"));
-                    ASSERT_THAT(proc.get()->capabilities, ::testing::ElementsAre("CAP_NET_RAW"));
-                    ASSERT_EQ(proc.get()->uid, 65534);
-                    ASSERT_EQ(proc.get()->gid, 65534);
-                } else if (proc.get()->get_name() == "failping") {
-                    ASSERT_EQ(proc.get()->path, "./ping");
-                    ASSERT_EQ(proc.get()->type, ChildProcess::ProcessType::ONESHOT);
-                    ASSERT_THAT(proc.get()->args, ::testing::ElementsAre("-c 4", "google.ch"));
-                    ASSERT_THAT(proc.get()->capabilities, ::testing::IsEmpty());
-                    ASSERT_EQ(proc.get()->uid, 65534);
-                    ASSERT_EQ(proc.get()->gid, 65534);
-                } else {
-                    FAIL() << "Found unexpected program element";
+            if (const auto &proc_base = weak_proc.lock().get()) {
+                if (auto proc = dynamic_cast<ChildProcess *>(proc_base)) {
+                    if (proc->get_name() == "ping") {
+                        ASSERT_EQ(proc->path, "./ping");
+                        ASSERT_EQ(proc->type, ChildProcess::ProcessType::ONESHOT);
+                        ASSERT_THAT(proc->args, ::testing::ElementsAre("-c 4", "google.ch"));
+                        ASSERT_THAT(proc->capabilities, ::testing::ElementsAre("CAP_NET_RAW"));
+                        ASSERT_EQ(proc->uid, 65534);
+                        ASSERT_EQ(proc->gid, 65534);
+                    } else if (proc->get_name() == "failping") {
+                        ASSERT_EQ(proc->path, "./ping");
+                        ASSERT_EQ(proc->type, ChildProcess::ProcessType::ONESHOT);
+                        ASSERT_THAT(proc->args, ::testing::ElementsAre("-c 4", "google.ch"));
+                        ASSERT_THAT(proc->capabilities, ::testing::IsEmpty());
+                        ASSERT_EQ(proc->uid, 65534);
+                        ASSERT_EQ(proc->gid, 65534);
+                    } else {
+                        FAIL() << "Found unexpected program element";
+                    }
                 }
             } else {
                 FAIL() << "Couldn't lock weak_ref!";
@@ -90,23 +92,25 @@ namespace scinit {
         auto procs = uut.get_processes();
         ASSERT_EQ(procs.size(), 2);
         for (auto &weak_proc : procs) {
-            if (auto proc = weak_proc.lock()) {
-                if (proc.get()->get_name() == "ping") {
-                    ASSERT_EQ(proc.get()->path, "./ping");
-                    ASSERT_EQ(proc.get()->type, ChildProcess::ProcessType::ONESHOT);
-                    ASSERT_THAT(proc.get()->args, ::testing::ElementsAre("-c 4", "google.ch"));
-                    ASSERT_THAT(proc.get()->capabilities, ::testing::ElementsAre("CAP_NET_RAW"));
-                    ASSERT_EQ(proc.get()->uid, 65534);
-                    ASSERT_EQ(proc.get()->gid, 65534);
-                } else if (proc.get()->get_name() == "failping") {
-                    ASSERT_EQ(proc.get()->path, "./ping");
-                    ASSERT_EQ(proc.get()->type, ChildProcess::ProcessType::ONESHOT);
-                    ASSERT_THAT(proc.get()->args, ::testing::ElementsAre("-c 4", "google.ch"));
-                    ASSERT_THAT(proc.get()->capabilities, ::testing::IsEmpty());
-                    ASSERT_EQ(proc.get()->uid, 65534);
-                    ASSERT_EQ(proc.get()->gid, 65534);
-                } else {
-                    FAIL() << "Found unexpected program element";
+            if (const auto &proc_base = weak_proc.lock().get()) {
+                if (auto proc = dynamic_cast<ChildProcess *>(proc_base)) {
+                    if (proc->get_name() == "ping") {
+                        ASSERT_EQ(proc->path, "./ping");
+                        ASSERT_EQ(proc->type, ChildProcess::ProcessType::ONESHOT);
+                        ASSERT_THAT(proc->args, ::testing::ElementsAre("-c 4", "google.ch"));
+                        ASSERT_THAT(proc->capabilities, ::testing::ElementsAre("CAP_NET_RAW"));
+                        ASSERT_EQ(proc->uid, 65534);
+                        ASSERT_EQ(proc->gid, 65534);
+                    } else if (proc->get_name() == "failping") {
+                        ASSERT_EQ(proc->path, "./ping");
+                        ASSERT_EQ(proc->type, ChildProcess::ProcessType::ONESHOT);
+                        ASSERT_THAT(proc->args, ::testing::ElementsAre("-c 4", "google.ch"));
+                        ASSERT_THAT(proc->capabilities, ::testing::IsEmpty());
+                        ASSERT_EQ(proc->uid, 65534);
+                        ASSERT_EQ(proc->gid, 65534);
+                    } else {
+                        FAIL() << "Found unexpected program element";
+                    }
                 }
             } else {
                 FAIL() << "Couldn't lock weak_ref!";
@@ -122,23 +126,25 @@ namespace scinit {
         auto procs = uut.get_processes();
         ASSERT_EQ(procs.size(), 2);
         for (auto &weak_proc : procs) {
-            if (auto proc = weak_proc.lock()) {
-                if (proc.get()->get_name() == "ping") {
-                    ASSERT_EQ(proc.get()->path, "./ping");
-                    ASSERT_EQ(proc.get()->type, ChildProcess::ProcessType::ONESHOT);
-                    ASSERT_THAT(proc.get()->args, ::testing::ElementsAre("-c 4", "google.ch"));
-                    ASSERT_THAT(proc.get()->capabilities, ::testing::ElementsAre("CAP_NET_RAW"));
-                    ASSERT_EQ(proc.get()->uid, 65534);
-                    ASSERT_EQ(proc.get()->gid, 65534);
-                } else if (proc.get()->get_name() == "failping") {
-                    ASSERT_EQ(proc.get()->path, "./ping");
-                    ASSERT_EQ(proc.get()->type, ChildProcess::ProcessType::ONESHOT);
-                    ASSERT_THAT(proc.get()->args, ::testing::ElementsAre("-c 4", "google.ch"));
-                    ASSERT_THAT(proc.get()->capabilities, ::testing::IsEmpty());
-                    ASSERT_EQ(proc.get()->uid, 65534);
-                    ASSERT_EQ(proc.get()->gid, 65534);
-                } else {
-                    FAIL() << "Found unexpected program element";
+            if (const auto &proc_base = weak_proc.lock().get()) {
+                if (auto proc = dynamic_cast<ChildProcess *>(proc_base)) {
+                    if (proc->get_name() == "ping") {
+                        ASSERT_EQ(proc->path, "./ping");
+                        ASSERT_EQ(proc->type, ChildProcess::ProcessType::ONESHOT);
+                        ASSERT_THAT(proc->args, ::testing::ElementsAre("-c 4", "google.ch"));
+                        ASSERT_THAT(proc->capabilities, ::testing::ElementsAre("CAP_NET_RAW"));
+                        ASSERT_EQ(proc->uid, 65534);
+                        ASSERT_EQ(proc->gid, 65534);
+                    } else if (proc->get_name() == "failping") {
+                        ASSERT_EQ(proc->path, "./ping");
+                        ASSERT_EQ(proc->type, ChildProcess::ProcessType::ONESHOT);
+                        ASSERT_THAT(proc->args, ::testing::ElementsAre("-c 4", "google.ch"));
+                        ASSERT_THAT(proc->capabilities, ::testing::IsEmpty());
+                        ASSERT_EQ(proc->uid, 65534);
+                        ASSERT_EQ(proc->gid, 65534);
+                    } else {
+                        FAIL() << "Found unexpected program element";
+                    }
                 }
             } else {
                 FAIL() << "Couldn't lock weak_ref!";
@@ -154,17 +160,19 @@ namespace scinit {
         auto procs = uut.get_processes();
         ASSERT_EQ(procs.size(), 1);
         for (auto &weak_proc : procs) {
-            if (auto proc = weak_proc.lock()) {
-                if (proc.get()->get_name() == "ping") {
-                    ASSERT_EQ(proc.get()->path, "./ping");
-                    ASSERT_EQ(proc.get()->type, ChildProcess::ProcessType::ONESHOT);
-                    ASSERT_THAT(proc.get()->args, ::testing::ElementsAre("-c 4", "google.ch"));
-                    ASSERT_THAT(proc.get()->capabilities, ::testing::ElementsAre("CAP_NET_RAW"));
-                    // Nobody and nogroup should be the same on every system
-                    ASSERT_EQ(proc.get()->uid, 65534);
-                    ASSERT_EQ(proc.get()->gid, 65534);
-                } else {
-                    FAIL() << "Found unexpected program element";
+            if (const auto &proc_base = weak_proc.lock().get()) {
+                if (auto proc = dynamic_cast<ChildProcess *>(proc_base)) {
+                    if (proc->get_name() == "ping") {
+                        ASSERT_EQ(proc->path, "./ping");
+                        ASSERT_EQ(proc->type, ChildProcess::ProcessType::ONESHOT);
+                        ASSERT_THAT(proc->args, ::testing::ElementsAre("-c 4", "google.ch"));
+                        ASSERT_THAT(proc->capabilities, ::testing::ElementsAre("CAP_NET_RAW"));
+                        // Nobody and nogroup should be the same on every system
+                        ASSERT_EQ(proc->uid, 65534);
+                        ASSERT_EQ(proc->gid, 65534);
+                    } else {
+                        FAIL() << "Found unexpected program element";
+                    }
                 }
             } else {
                 FAIL() << "Couldn't lock weak_ref!";

--- a/test/test_configs/test-stdouterr.yml
+++ b/test/test_configs/test-stdouterr.yml
@@ -1,0 +1,3 @@
+programs:
+  - name: iotest
+    path: test/stdouterr

--- a/test/test_integration.cpp
+++ b/test/test_integration.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 The scinit authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "../src/Config.h"
+#include "../src/log.h"
+#include "MockEventHandlers.h"
+#include "integration_test/MockChildProcess.h"
+#include "integration_test/MockProcessHandler.h"
+
+using ::testing::Return;
+using ::testing::_;
+using namespace scinit::test::integration;
+
+namespace scinit {
+    class IntegrationTests : public testing::Test {
+      protected:
+        fs::path test_resource;
+
+        void SetUp() override {
+            test_resource = fs::path(__FILE__);
+            ASSERT_TRUE(fs::is_regular_file(test_resource)) << "Path to source does not point to a regular file";
+            test_resource.remove_filename();
+            test_resource /= "test_configs";
+            ASSERT_TRUE(fs::is_directory(test_resource)) << "Test resource directory is missing";
+            if (!spdlog::get("scinit")) {
+                auto console = spdlog::stdout_color_st("scinit");
+                console->set_pattern("[%^%n%$] [%H:%M:%S.%e] [%l] %v");
+                console->set_level(spdlog::level::critical);
+            }
+        }
+
+        void TearDown() override { spdlog::drop_all(); }
+    };
+
+    TEST_F(IntegrationTests, TestStdOutErr) {
+        auto test_program = fs::path(test_resource);
+        test_resource /= "test-stdouterr.yml";
+        test_program = test_program.parent_path();
+        test_program = test_program.parent_path();
+        test_program /= "build";
+        test_program /= "test";
+        test_program /= "stdouterr";
+        ASSERT_TRUE(fs::is_regular_file(test_resource)) << "Test resource missing";
+        ASSERT_TRUE(fs::is_regular_file(test_program)) << "Test resource missing";
+        auto handler = std::make_shared<MockProcessHandler>();
+        auto config = std::make_unique<scinit::Config<MockChildProcess>>(test_resource.native(), handler);
+        auto child_list = config->get_processes();
+        ASSERT_EQ(child_list.size(), 1);
+        auto child_ptr = dynamic_cast<MockChildProcess*>(child_list.begin()->lock().get());
+        child_ptr->path = test_program.native();
+
+        handler->register_processes(child_list);
+        handler->should_quit = true;
+        ASSERT_EQ(child_ptr->get_state(), ChildProcessInterface::ProcessState::READY);
+        handler->enter_eventloop();
+        ASSERT_EQ(child_ptr->get_state(), ChildProcessInterface::ProcessState::DONE);
+        ASSERT_EQ(handler->getStdout(), "Something to stdout");
+        ASSERT_EQ(handler->getStderr(), "Something to stderr");
+    }
+}  // namespace scinit

--- a/test/test_process_handler.cpp
+++ b/test/test_process_handler.cpp
@@ -42,7 +42,7 @@ namespace scinit {
         auto child_1 = std::make_shared<MockChildProcess>();
         EXPECT_CALL(*child_1, can_start_now()).WillRepeatedly(Return(true));
         EXPECT_CALL(*child_1, do_fork(_)).Times(1);
-        EXPECT_CALL(*child_1, register_with_epoll(_, _)).Times(1);
+        EXPECT_CALL(*child_1, register_with_epoll(_, _, _)).Times(1);
         EXPECT_CALL(*child_1, get_name()).Times(2).WillRepeatedly(Return("mockprog"));
         std::list<std::weak_ptr<ChildProcessInterface>> all_children;
         all_children.push_back(child_1);
@@ -58,7 +58,7 @@ namespace scinit {
         auto child_1 = std::make_shared<MockChildProcess>();
         EXPECT_CALL(*child_1, can_start_now()).WillRepeatedly(Return(true));
         EXPECT_CALL(*child_1, do_fork(_)).Times(1);
-        EXPECT_CALL(*child_1, register_with_epoll(_, _)).Times(1);
+        EXPECT_CALL(*child_1, register_with_epoll(_, _, _)).Times(1);
         EXPECT_CALL(*child_1, get_name()).Times(3).WillRepeatedly(Return("mockprog"));
         std::list<std::weak_ptr<ChildProcessInterface>> all_children;
         all_children.push_back(child_1);

--- a/test/test_process_lifecycle.cpp
+++ b/test/test_process_lifecycle.cpp
@@ -57,9 +57,10 @@ namespace scinit {
                   reg[pid] = child->get_id();
               }));
             EXPECT_CALL(*register_event, call_once()).Times(1);
-            EXPECT_CALL(*child, register_with_epoll(_, _))
+            EXPECT_CALL(*child, register_with_epoll(_, _, _))
               .Times(1)
-              .WillOnce(Invoke([register_event](int, std::map<int, unsigned int>& map) {
+              .WillOnce(Invoke([register_event](int, std::map<int, unsigned int>& map,
+                                                std::map<int, ProcessHandlerInterface::FDType>&) {
                   register_event->call_once();
                   map[0] = 0;
               }));

--- a/test/test_programs/stdouterr.cpp
+++ b/test/test_programs/stdouterr.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 The scinit authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+
+// Output stuff to stdout and stderr
+int main(int, char**) {
+    std::cout << "Something to stdout" << std::endl;
+    std::cerr << "Something to stderr" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
This helps apps that crash if stdout and stderr happen to be the same
file descriptor. Additionally, add a test so that the pipes don't get
mixed up.